### PR TITLE
hours: Change format to use day keys instead of list

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     -   id: name-tests-test
     -   id: pretty-format-json
         args: [
-            '--top-keys', '$schema,$id,definitions,type,properties,required',
+            '--no-sort-keys',
             '--autofix',
         ]
     -   id: requirements-txt-fixer

--- a/hours.yaml
+++ b/hours.yaml
@@ -1,19 +1,28 @@
-regular: # Starts on Monday
-  - ['9:00', '18:00']
-  - ['9:00', '20:00']
-  - ['9:00', '20:00']
-  - ['9:00', '20:00']
-  - ['9:00', '18:00']
-  - ['9:00', '20:00']
+regular:
+  Monday:
+    - ['9:00', '18:00']
+  Tuesday:
+    - ['9:00', '20:00']
+  Wednesday:
+    - ['9:00', '20:00']
+  Thursday:
+    - ['9:00', '20:00']
+  Friday:
+    - ['9:00', '18:00']
+  Saturday:
+    - ['9:00', '20:00']
+  Sunday:
   - ['9:00', '20:00']
 holidays:
   - date: [2018-11-21, 2018-11-25]
     reason: Thanksgiving Break
   - date: 2018-12-03
     reason: Late Lab Opening
-    hours: ['10:00', '18:00']
+    hours:
+      - ['10:00', '18:00']
   - date: 2018-12-14
     reason: Last Day of Finals
-    hours: ['9:00', '14:00']
+    hours:
+      - ['9:00', '14:00']
   - date: [2018-12-15, 2019-01-14]
     reason: Winter Break

--- a/schemas/hours.schema.json
+++ b/schemas/hours.schema.json
@@ -31,7 +31,7 @@
           ]
         },
         "hours": {
-          "$ref": "#/definitions/timerange"
+          "$ref": "#/definitions/timeranges"
         },
         "reason": {
           "type": "string"
@@ -57,6 +57,12 @@
           "$ref": "#/definitions/time"
         }
       ]
+    },
+    "timeranges": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/timerange"
+      }
     }
   },
   "type": "object",
@@ -68,12 +74,40 @@
       }
     },
     "regular": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/timerange"
+      "type": "object",
+      "properties": {
+        "Monday": {
+          "$ref": "#/definitions/timeranges"
+        },
+        "Tuesday": {
+          "$ref": "#/definitions/timeranges"
+        },
+        "Wednesday": {
+          "$ref": "#/definitions/timeranges"
+        },
+        "Thursday": {
+          "$ref": "#/definitions/timeranges"
+        },
+        "Friday": {
+          "$ref": "#/definitions/timeranges"
+        },
+        "Saturday": {
+          "$ref": "#/definitions/timeranges"
+        },
+        "Sunday": {
+          "$ref": "#/definitions/timeranges"
+        }
       },
-      "maxItems": 7,
-      "minItems": 7
+      "required": [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday"
+      ],
+      "additionalProperties": false
     }
   },
   "required": [


### PR DESCRIPTION
The alternative to #7. This uses a dictionary which I guess is more explicit.