### PR TITLE
Add staff hours

### DIFF
--- a/configs/staff_hours.yaml
+++ b/configs/staff_hours.yaml
@@ -13,10 +13,15 @@
 #     staff: ["gstaff"]
 #  Tuesday:
 #  ...
+#
+# If you're modifying this file, if it passes the tests then you can just
+# merge the change on github without needing an approval.
 ---
 
 staff-hours:
   Monday:
+   - time: ['11:00', '11:00']
+     staff: ["gstaff"]
   Tuesday:
   Wednesday:
   Thursday:

--- a/configs/staff_hours.yaml
+++ b/configs/staff_hours.yaml
@@ -34,5 +34,4 @@ staff-positions:
  - username: "ethanhs"
    position: "Site Manager"
 
-    # rootstaff can optionally label themselves as "technical managers" below:
 # vim: set expandtab:ts=4:sw=4

--- a/configs/staff_hours.yaml
+++ b/configs/staff_hours.yaml
@@ -1,0 +1,38 @@
+# Authoritative staff hours file.
+#
+# The online staff hours page is dynamically generated based on the
+# contents of this file.
+#
+# Be sure to use spaces instead of tabs for indentation of this file.
+#
+# An example staff hours entry looks like:
+#
+# staff-hours:
+#  Monday:
+#   - time: ['11:00', '13:00']
+#     staff: ["gstaff"]
+#  Tuesday:
+#  ...
+---
+
+staff-hours:
+  Monday:
+  Tuesday:
+  Wednesday:
+  Thursday:
+  Friday:
+  Saturday:
+  Sunday:
+
+staff-positions:
+ - username: "php"
+   position: "General Manager"
+ - username: "cooperc"
+   position: "General Manager"
+ - username: "fydai"
+   position: "Site Manager"
+ - username: "ethanhs"
+   position: "Site Manager"
+
+    # rootstaff can optionally label themselves as "technical managers" below:
+# vim: set expandtab:ts=4:sw=4

--- a/configs/validate.yaml
+++ b/configs/validate.yaml
@@ -4,5 +4,8 @@ hours:
 lab_status:
   schema: lab_status.schema.json
 
+staff_hours:
+  schema: staff_hours.schema.json
+
 validate:
   schema: validate.schema.json

--- a/schemas/staff_hours.schema.json
+++ b/schemas/staff_hours.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://ocf.berkeley.edu/schemas/staff_hours.schema.json",
+  "definitions": {
+    "time": {
+      "type": "string",
+      "pattern": "^[012]?[0-9]:[0-9][0-9]$"
+    },
+    "timerange": {
+      "type": "array",
+      "items": [
+        {
+          "$ref": "#/definitions/time"
+        },
+        {
+          "$ref": "#/definitions/time"
+        }
+      ]
+    },
+    "day": {
+      "type": "string",
+      "enum": [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday"
+      ]
+    },
+    "staff_hours_entry": {
+      "type": "object",
+      "properties": {
+        "day": {
+          "$ref": "#/definitions/day"
+        },
+        "time": {
+          "$ref": "#/definitions/timerange"
+        },
+        "staff": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "day",
+        "time",
+        "staff"
+      ],
+      "additionalProperties": false
+    },
+    "staff_position": {
+      "type": "object",
+      "properties": {
+        "username": {
+          "type": "string"
+        },
+        "position": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "username",
+        "position"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "properties": {
+    "staff-hours": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/staff_hours_entry"
+      }
+    },
+    "staff-positions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/staff_position"
+      }
+    }
+  },
+  "required": [
+    "staff-hours",
+    "staff-positions"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/staff_hours.schema.json
+++ b/schemas/staff_hours.schema.json
@@ -38,6 +38,15 @@
       ],
       "additionalProperties": false
     },
+    "staff_hours_entry_array": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/staff_hours_entry"
+      }
+    },
     "staff_position": {
       "type": "object",
       "properties": {
@@ -61,67 +70,25 @@
       "type": "object",
       "properties": {
         "Monday": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/staff_hours_entry"
-          }
+          "$ref": "#/definitions/staff_hours_entry_array"
         },
         "Tuesday": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/staff_hours_entry"
-          }
+          "$ref": "#/definitions/staff_hours_entry_array"
         },
         "Wednesday": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/staff_hours_entry"
-          }
+          "$ref": "#/definitions/staff_hours_entry_array"
         },
         "Thursday": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/staff_hours_entry"
-          }
+          "$ref": "#/definitions/staff_hours_entry_array"
         },
         "Friday": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/staff_hours_entry"
-          }
+          "$ref": "#/definitions/staff_hours_entry_array"
         },
         "Saturday": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/staff_hours_entry"
-          }
+          "$ref": "#/definitions/staff_hours_entry_array"
         },
         "Sunday": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/staff_hours_entry"
-          }
+          "$ref": "#/definitions/staff_hours_entry_array"
         }
       },
       "required": [

--- a/schemas/staff_hours.schema.json
+++ b/schemas/staff_hours.schema.json
@@ -17,24 +17,9 @@
         }
       ]
     },
-    "day": {
-      "type": "string",
-      "enum": [
-        "Monday",
-        "Tuesday",
-        "Wednesday",
-        "Thursday",
-        "Friday",
-        "Saturday",
-        "Sunday"
-      ]
-    },
     "staff_hours_entry": {
       "type": "object",
       "properties": {
-        "day": {
-          "$ref": "#/definitions/day"
-        },
         "time": {
           "$ref": "#/definitions/timerange"
         },
@@ -48,7 +33,6 @@
         }
       },
       "required": [
-        "day",
         "time",
         "staff"
       ],
@@ -74,10 +58,82 @@
   "type": "object",
   "properties": {
     "staff-hours": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/staff_hours_entry"
-      }
+      "type": "object",
+      "properties": {
+        "Monday": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/staff_hours_entry"
+          }
+        },
+        "Tuesday": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/staff_hours_entry"
+          }
+        },
+        "Wednesday": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/staff_hours_entry"
+          }
+        },
+        "Thursday": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/staff_hours_entry"
+          }
+        },
+        "Friday": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/staff_hours_entry"
+          }
+        },
+        "Saturday": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/staff_hours_entry"
+          }
+        },
+        "Sunday": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/staff_hours_entry"
+          }
+        }
+      },
+      "required": [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday"
+      ],
+      "additionalProperties": false
     },
     "staff-positions": {
       "type": "array",


### PR DESCRIPTION
Fixes #6

I decided while I was at it to rewrite the format to the one vaibhav was working on, since it looks better  IMO. I'll dig up his PR when rewriting the ocflib code, or if he wants to work on it again, that would be very much appreciated.

I wanted to keep canceling staff hours fast and simple, so I was thinking that `ocflib` would read a file of newline-separated usernames from `~staff` and cancel staff hours from those usernames--if the file was malformed or didn't exist, the ocflib code would assume that no staff hours were canceled.

If you think that making a PR to `etc` is not too high a barrier for canceling, or have a better method in mind, pls suggest.