### PR TITLE
Add cancellation field to staff hours.

### DIFF
--- a/configs/staff_hours.yaml
+++ b/configs/staff_hours.yaml
@@ -25,13 +25,34 @@
 
 staff-hours:
   Monday:
-   - time: ['11:00', '11:00']
-     staff: ["gstaff"]
-     cancelled: true
+   - time: ['10:00', '12:00']
+     staff: ['cooperc']
+   - time: ['12:30', '14:30']
+     staff: ['wporr']
   Tuesday:
+   - time: ['9:00', '10:30']
+     staff: ['minos']
+   - time: ['12:30', '15:30']
+     staff: ['fydai']
+   - time: ['15:00', '16:00']
+     staff: ['php']
   Wednesday:
+   - time: ['11:00', '12:30']
+     staff: ['cooperc']
+   - time: ['15:00', '16:00']
+     staff: ['php']
+   - time: ['16:00', '17:00']
+     staff: ['gleeb']
   Thursday:
+   - time: ['9:00', '10:30']
+     staff: ['minos']
+   - time: ['12:00', '13:00']
+     staff: ['bzh']
   Friday:
+   - time: ['13:00', '14:00']
+     staff: ['ethanhs']
+   - time: ['14:00', '15:00']
+     staff: ['jaw']
   Saturday:
   Sunday:
 

--- a/configs/staff_hours.yaml
+++ b/configs/staff_hours.yaml
@@ -11,6 +11,7 @@
 #  Monday:
 #   - time: ['11:00', '13:00']
 #     staff: ["gstaff"]
+#     cancelled: false
 #  Tuesday:
 #  ...
 #
@@ -22,6 +23,7 @@ staff-hours:
   Monday:
    - time: ['11:00', '11:00']
      staff: ["gstaff"]
+     cancelled: false
   Tuesday:
   Wednesday:
   Thursday:

--- a/configs/staff_hours.yaml
+++ b/configs/staff_hours.yaml
@@ -11,9 +11,13 @@
 #  Monday:
 #   - time: ['11:00', '13:00']
 #     staff: ["gstaff"]
-#     cancelled: false
 #  Tuesday:
+#   - time: ['10:00', '11:00']
+#     staff: ["bzh"]
+#     cancelled: true
 #  ...
+#
+# The `cancelled` field is optional, and defaults to false if not included.
 #
 # If you're modifying this file, if it passes the tests then you can just
 # merge the change on github without needing an approval.
@@ -23,7 +27,7 @@ staff-hours:
   Monday:
    - time: ['11:00', '11:00']
      staff: ["gstaff"]
-     cancelled: false
+     cancelled: true
   Tuesday:
   Wednesday:
   Thursday:

--- a/schemas/staff_hours.schema.json
+++ b/schemas/staff_hours.schema.json
@@ -37,8 +37,7 @@
       },
       "required": [
         "time",
-        "staff",
-        "cancelled"
+        "staff"
       ],
       "additionalProperties": false
     },

--- a/schemas/staff_hours.schema.json
+++ b/schemas/staff_hours.schema.json
@@ -30,11 +30,15 @@
           },
           "minItems": 1,
           "uniqueItems": true
+        },
+        "cancelled": {
+          "type": "boolean"
         }
       },
       "required": [
         "time",
-        "staff"
+        "staff",
+        "cancelled"
       ],
       "additionalProperties": false
     },


### PR DESCRIPTION
I didn't think of what happens if one person has multiple staff hours, so I think just adding this field is simpler all around. 