### PR TITLE
Remove Monday staff hours for kmo

### DIFF
--- a/configs/staff_hours.yaml
+++ b/configs/staff_hours.yaml
@@ -27,8 +27,6 @@ staff-hours:
   Monday:
    - time: ['11:00', '12:30']
      staff: ['cooperc']
-   - time: ['14:30', '17:00']
-     staff: ['kmo']
    - time: ['16:00', '18:00']
      staff: ['snarain']
   Tuesday:


### PR DESCRIPTION
Doing this so I can leave the rest of the week open for my schedule. I'll still be doing staff hours during the end of the week when there's more free time.