### PR TITLE
extend public health closure

### DIFF
--- a/configs/hours.yaml
+++ b/configs/hours.yaml
@@ -112,5 +112,5 @@ holidays:
     reason: Public Health Closure
   - date: [2020-03-21, 2020-03-29]
     reason: Spring Break
-  - date: [2020-03-30, 2020-05-03]
+  - date: [2020-03-30, 2020-05-31]
     reason: Public Health Closure


### PR DESCRIPTION
"through may 31" https://www.cityofberkeley.info/City_Manager/Press_Releases/2020/2020-04-29_Regional_shelter-in-place_orders_extended_as_some_rules_ease.aspx