### PR TITLE
update bluegold apphost domain

### DIFF
--- a/configs/vhost-app.conf
+++ b/configs/vhost-app.conf
@@ -24,8 +24,8 @@ nanotech - - -
 # in-person
 spaceenterprise seb - -
 
-# rt#10323
-bluegold yearbook.apphost.ocf.berkeley.edu - -
+# rt#10323, rt#10872
+bluegold yearbook - -
 
 # added in staff hours 2021-08-27
 fintech quant - -


### PR DESCRIPTION
Switch to yearbook.be (this changes dev domain to yearbook-berkeley-edu.apphost.ocf.berkeley.edu)
