### PR TITLE
Add inm mail vhost per rt10898

### DIFF
--- a/configs/vhost-mail.conf
+++ b/configs/vhost-mail.conf
@@ -6,6 +6,9 @@ ggroup vhost.berkeley.edu
 ggroup dev-vhost.ocf.berkeley.edu
 ggroup dev-dev-vhost.ocf.berkeley.edu
 
+# rt#10898
+inm inm.berkeley.edu
+
 # rt#10889
 calproductspace product.berkeley.edu
 


### PR DESCRIPTION
MX record verified:
```
; <<>> DiG 9.16.1-Ubuntu <<>> @8.8.8.8 inm.berkeley.edu MX
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 41717
;; flags: qr rd ra ad; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;inm.berkeley.edu.              IN      MX

;; ANSWER SECTION:
inm.berkeley.edu.       10800   IN      MX      5 anthrax.ocf.berkeley.edu.

;; Query time: 23 msec
;; SERVER: 8.8.8.8#53(8.8.8.8)
;; WHEN: Fri Dec 17 22:33:24 PST 2021
;; MSG SIZE  rcvd: 73
```