### PR TITLE
staff_hours: remove unnecessary entries in staff-positions

### DIFF
--- a/configs/staff_hours.yaml
+++ b/configs/staff_hours.yaml
@@ -50,7 +50,5 @@ staff-positions:
    position: "Site Manager"
  - username: "njha"
    position: "Deputy Site Manager"
- - username: "laksith"
-   position: "Ocf Staff"
 
 # vim: set expandtab:ts=4:sw=4


### PR DESCRIPTION
The `staff-positions` dict is only needed for \*Ms and other positions not tracked in LDAP, "OCF Staff" / technical manager are handled automatically.