### PR TITLE
Flag dev app vhosts

### DIFF
--- a/configs/vhost-app.conf
+++ b/configs/vhost-app.conf
@@ -10,20 +10,22 @@
 #               (use - to default to ocf account name)
 # aliases - comma-separated aliases list, must be FQDNs
 # [flags] - (optional) [comma-separated list of flags]
-#           Currently the only supported flag is ws=path
-#.          to add a websocket path.
+#           supported flags:
+#           - ws=path to add a websocket path
+#           - dev to mark a site as in development,
+#             available at group-berkeley-edu.apphost.o.b.e
 #
 
 # rt#13170
-calttc calttc.berkeley.edu - -
+calttc calttc.berkeley.edu - - [dev]
 
 # etw in-person (move from webhost)
 # Make animage.berkeley.edu not redirect to cal.moe
 animage cal.moe - calanimagealpha.com
-animage animage.berkeley.edu - -
+animage animage.berkeley.edu - - [dev]
 
 # rt#12483
-ucbugg ucbugg.berkeley.edu - -
+ucbugg ucbugg.berkeley.edu - - [dev]
 
 # ronitnath
 lead app-lead.berkeley.edu - -
@@ -41,13 +43,13 @@ spaceenterprise seb.berkeley.edu - -
 bluegold yearbook.berkeley.edu - -
 
 # added in staff hours 2021-08-27
-fintech quant.berkeley.edu - -
+fintech quant.berkeley.edu - - [dev]
 
 # rt#9810
 plextech plextech.berkeley.edu - -
 
 # staff hours
-bmt bmt-guts.berkeley.edu - -
+bmt bmt-guts.berkeley.edu - - [dev]
 
 # rt#9534
 statusa susa.berkeley.edu - -
@@ -65,7 +67,7 @@ pcs pcs.berkeley.edu - -
 csa csa.berkeley.edu - -
 
 # rt#9394
-dssb dss.berkeley.edu - -
+dssb dss.berkeley.edu - - [dev]
 
 # added 2020-08-08 wqnguyen rt#9353
 itot itot.berkeley.edu - -
@@ -90,10 +92,10 @@ launchpad launchpad.berkeley.edu - -
 slrpev slrpev.berkeley.edu - -
 
 # added 2020-05-03 jaw rt#9062
-bconsult bc.berkeley.edu - -
+bconsult bc.berkeley.edu - - [dev]
 
 # added 2019-01-24 fydai in-person
-techsocialimpact techsocialimpact.berkeley.edu - -
+techsocialimpact techsocialimpact.berkeley.edu - - [dev]
 
 # added 2019-09-27 abizer rt#8533
 # disabled 2020-02-11 cooperc
@@ -106,25 +108,25 @@ techsocialimpact techsocialimpact.berkeley.edu - -
 msa wiki.berkeleymsa.org - -
 
 # added 2019-07-8 abizer rt#8337
-ddsa ddsa.berkeley.edu - -
+ddsa ddsa.berkeley.edu - - [dev]
 
 # added 2019-05-16 dkessler rt#8274
-rcs rcsainternal.berkeley.edu rcsainternal -
+rcs rcsainternal.berkeley.edu rcsainternal - [dev]
 
 # added 2019-05-10 mdcha rt#8268
-mobile mdb.berkeley.edu - -
+mobile mdb.berkeley.edu - - [dev]
 
 # added 2019-05-02 dkessler rt#8236
-tellab tellab.berkeley.edu - -
+tellab tellab.berkeley.edu - - [dev]
 
 # added 2019-04-18 abizer/cooperc rt#8207
-space star-telemetry.berkeley.edu - -
+space star-telemetry.berkeley.edu - - [dev]
 
 # added 2019-01-23 keur in-person
-bmt bmt.berkeley.edu - -
+bmt bmt.berkeley.edu - - [dev]
 
 # added 2019-01-22 abizer rt#7954
-bfsc figureskating.berkeley.edu - -
+bfsc figureskating.berkeley.edu - - [dev]
 
 # added 2019-01-15 abizer rt#7929
 bioehs bioehs.berkeley.edu - -
@@ -132,19 +134,19 @@ bioehs bioehs.berkeley.edu - -
 # 2018-11-28 dkessler in-person
 # note that their DNS doesn't actually point to us yet
 # see rt#7822
-beacon beacon.berkeley.edu - -
+beacon beacon.berkeley.edu - - [dev]
 
 # 2018-09-28 mdcha in-person [actually mdcha messed up, apphosting not necessary --cooperc]
 # pvc - - -
 
 # 2018-09-20 mdcha in-person
-neurotech neurotech.berkeley.edu - -
+neurotech neurotech.berkeley.edu - - [dev]
 
 # 2018-06-22 abizer rt#7396
 eatb entrepreneurs.berkeley.edu - -
 
 # 2018-05-08 abizer rt#7277
-ksea ksea.berkeley.edu - -
+ksea ksea.berkeley.edu - - [dev]
 
 # 2018-05-03 abizer in-person (rt#7325 too)
 hackthebay 2018.calhacks.io hackthebay -
@@ -152,7 +154,7 @@ hackthebay 2018-dev.calhacks.io dev -
 hackthebay live.calhacks.io live -
 
 # 2018-04-25 jvperrin in-person
-marketplace marketplace.berkeley.edu - -
+marketplace marketplace.berkeley.edu - - [dev]
 
 # 2018-04-25 kuoh rt#7297
 microfluidics microfluidics.berkeley.edu - -
@@ -164,7 +166,7 @@ microfluidics microfluidics.berkeley.edu - -
 # 2018-02-22 abizer rt#7085
 # 2018-11-04 jvperrin Removed, invalid DNS, nonworking apphost
 # 2020-04-02 jaw reenabled as they'd like to rebuild
-wsladmin wordsoundlife.berkeley.edu - -
+wsladmin wordsoundlife.berkeley.edu - - [dev]
 # 2020-05-28 jaw temporary socket rt#8989
 wsladmin wslradio.apphost.ocf.berkeley.edu wslradio -
 
@@ -172,7 +174,7 @@ wsladmin wslradio.apphost.ocf.berkeley.edu wslradio -
 isab isab.berkeley.edu - -
 
 # 2018-02-01 abizer rt#7030
-llp llp.berkeley.edu - -
+llp llp.berkeley.edu - - [dev]
 
 # 2017-12-18 abizer rt#6909 tentatively approved for dev purposes
 # 2018-01-13 jvperrin rt#6909 vhost submitted to hostmaster
@@ -183,7 +185,7 @@ kunakorea kuna.berkeley.edu - -
 tbp tbp.berkeley.edu - -
 
 # 2017-09-08 mattmcal rt#6532
-ieee ieee.berkeley.edu - -
+ieee ieee.berkeley.edu - - [dev]
 
 # 2017-08-27 jvperrin in-person
 hkn dev-hkn.eecs.berkeley.edu dev dev.hkn.mu
@@ -256,7 +258,7 @@ upe upe.apphost.ocf.berkeley.edu - -
 tasa tasa.berkeley.edu - -
 
 # 2015-11-15 ckuehl rt#4105
-hboiled hardboiled.berkeley.edu - -
+hboiled hardboiled.berkeley.edu - - [dev]
 
 # 2015-03-08 ckuehl rt#3394
 see see.berkeley.edu - -


### PR DESCRIPTION
Flag dev app vhosts so they don't clobber existing vhost entries on death while in development. Depends on #516 