### PR TITLE
Close Lab for Thanksgiving

### DIFF
--- a/configs/hours.yaml
+++ b/configs/hours.yaml
@@ -325,3 +325,5 @@ holidays:
     reason: Reduced Hours for Internal Event # Halloween social
     hours:
       - ['12:00', '17:00']
+  - date: [2023-11-20, 2023-11-25]
+    reason: Thanksgiving Break


### PR DESCRIPTION
Most operations staff are flying home. We may still have volunteer staff open and maintain the lab unofficially (and uncompensated), but the lab will be officially closed.