### PR TITLE
Increase Saturday Hours

### DIFF
--- a/configs/hours.yaml
+++ b/configs/hours.yaml
@@ -10,7 +10,7 @@ regular:
   Friday:
     - ['9:00', '20:00']
   Saturday:
-    - ['12:00', '18:00']
+    - ['10:00', '18:00']
   Sunday: null
 holidays:
   - date: [2018-11-21, 2018-11-25]


### PR DESCRIPTION
No more SWE++, meaning we can now open to the public 2 hours earlier on Saturdays.