### PR TITLE
Add .studentorg.b.e mirrors to existing .b.e vhosts

### DIFF
--- a/configs/vhost.conf
+++ b/configs/vhost.conf
@@ -55,6 +55,7 @@ realtalkbuddies realtalkbuddies.studentorg.berkeley.edu - -
 
 # rt#12911
 calcodeology codeology.berkeley.edu - -
+calcodeology codeology.studentorg.berkeley.edu - - [noindex]
 
 # rt#13207
 codeforgood codeforgood.berkeley.edu - -
@@ -70,157 +71,184 @@ bikebuilders bikebuilders.berkeley.edu - -
 
 # rt#11998
 ostem ostem.berkeley.edu - -
+ostem ostem.studentorg.berkeley.edu - - [noindex]
 
 # rt#11889
 autolab autolab.berkeley.edu - /public
+autolab autolab.studentorg.berkeley.edu - /public [noindex]
 
 # rt#11849
 pokeratberkeley poker.berkeley.edu - -
+pokeratberkeley poker.studentorg.berkeley.edu - - [noindex]
 
 # rt#11963
 detrash detrash.studentorg.berkeley.edu - -
 
 # rt#11684
 dgab dancegames.berkeley.edu - -
+dgab dancegames.studentorg.berkeley.edu - - [noindex]
 
 # rt#11840
-powerbayarea powerbayarea.berkeley.edu - -
+powerbayarea powerbayarea.berkeley.edu powerbayarea.studentorg.berkeley.edu -
 
 # rt#10954
 hellmanlab hellmanlab.berkeley.edu - -
 
 # rt#11699
-rhitishah grc.berkeley.edu - -
+rhitishah grc.berkeley.edu grc.studentorg.berkeley.edu -
 
 # rt#11572
 sensibility sensibility.berkeley.edu - -
+sensibility sensibility.studentorg.berkeley.edu - - [noindex]
 
 # rt#11516
-bioscienceallian biox.berkeley.edu - -
+bioscienceallian biox.berkeley.edu biox.studentorg.berkeley.edu -
 
 # rt#11499
-areddie reddie.berkeley.edu reddie.ischool.berkeley.edu -
+areddie reddie.berkeley.edu reddie.ischool.berkeley.edu,reddie.studentorg.berkeley.edu -
 
 # rt#11500
-studiogeo studiogeo.berkeley.edu - -
+studiogeo studiogeo.berkeley.edu studiogeo.studentorg.berkeley.edu -
 
 # rt#11217
-housingcomm housingcomm.berkeley.edu www.housingcomm.berkeley.edu -
+housingcomm housingcomm.berkeley.edu www.housingcomm.berkeley.edu,housingcomm.studentorg.berkeley.edu -
 
 # rt#11189
 cqg cqg.berkeley.edu - -
+cqg cqg.studentorg.berkeley.edu - - [noindex]
 
 # rt#11185
 metaverse metaverse.berkeley.edu - -
+metaverse metaverse.studentorg.berkeley.edu - - [noindex]
 
 # rt#11036
 uic uic.berkeley.edu - -
+uic uic.studentorg.berkeley.edu - - [noindex]
 
 # rt#11005
 cluj cluj.berkeley.edu - -
+cluj cluj.studentorg.berkeley.edu - - [noindex]
 
 # rt#10962
-berkeleyapsa apsa.berkeley.edu - -
+berkeleyapsa apsa.berkeley.edu apsa.studentorg.berkeley.edu -
 
 # in-person
 eecsdiscord eecsdiscord.berkeley.edu - -
+eecsdiscord eecsdiscord.studentorg.berkeley.edu - - [noindex]
 
 # rt#10942
 # bmf mfb - -
 
 # rt#10837
 inm inm.berkeley.edu - -
+inm inm.studentorg.berkeley.edu - - [noindex]
 
 # rt#10767
-define definetwork.berkeley.edu - -
+define definetwork.berkeley.edu definetwork.studentorg.berkeley.edu -
 
 # ocf merch store
 fcomerch merch.ocf.berkeley.edu merch.ocf.io -
 
 # rt#10435
-abetterway abw.berkeley.edu - -
+abetterway abw.berkeley.edu abw.studentorg.berkeley.edu -
 
 # rt#10485
-stemcellcenter stemcellcenter.berkeley.edu thestemcellcenter.berkeley.edu -
+stemcellcenter stemcellcenter.berkeley.edu thestemcellcenter.berkeley.edu,stemcellcenter.studentorg.berkeley.edu -
 
 # rt#10495 + staff hours
 calico calico.cs.berkeley.edu calico.berkeley.edu -
 
 # rt10426
 syz syz.berkeley.edu - -
+syz syz.studentorg.berkeley.edu - - [noindex]
 
 # rt#10371
-transpo transpo.berkeley.edu - -
+transpo transpo.berkeley.edu transpo.studentorg.berkeley.edu -
 
 # rt#10412
 calproductspace product.berkeley.edu - -
+calproductspace product.studentorg.berkeley.edu - - [noindex]
 
 # rt#10408
-comproj compass.berkeley.edu - -
+comproj compass.berkeley.edu compass.studentorg.berkeley.edu -
 
 # requested directly
-silverlab argentum.ucbso.berkeley.edu - -
+silverlab argentum.ucbso.berkeley.edu argentum.ucbso.studentorg.berkeley.edu -
 
 # rt#10264
 ujpb ujpb.berkeley.edu - -
+ujpb ujpb.studentorg.berkeley.edu - - [noindex]
 
 # personal email
-connectedgov connectedgov.berkeley.edu - -
+connectedgov connectedgov.berkeley.edu connectedgov.studentorg.berkeley.edu -
 
 # rt#10128
-jmcb jmc.berkeley.edu - -
+jmcb jmc.berkeley.edu jmc.studentorg.berkeley.edu -
 
 # rt#10126
 balsaralab balsaralab.berkeley.edu - -
+balsaralab balsaralab.studentorg.berkeley.edu - - [noindex]
 
 # rt#10094
 # Temporarily disable until new site is up, re rt#10427
 # futurepain - - -
 
 # staff hours
-dancethebay dancethebay.berkeley.edu - -
+dancethebay dancethebay.berkeley.edu dancethebay.studentorg.berkeley.edu -
 
 # rt#10003
 powerandenergy powerandenergy.berkeley.edu - -
+powerandenergy powerandenergy.studentorg.berkeley.edu - - [noindex]
 
 # rt#10108
-hockemeyerlab hockemeyerlab.berkeley.edu - -
+hockemeyerlab hockemeyerlab.berkeley.edu hockemeyerlab.studentorg.berkeley.edu -
 
 # rt#10080, rt#11721
 cwg cmgg.berkeley.edu - -
+cwg cmgg.studentorg.berkeley.edu - - [noindex]
 
 # rt#10011
 paneltothepeople p2tp.berkeley.edu - -
+paneltothepeople p2tp.studentorg.berkeley.edu - - [noindex]
 
 # staff hours
-disabilitylab disabilitylab.berkeley.edu - -
+disabilitylab disabilitylab.berkeley.edu disabilitylab.studentorg.berkeley.edu -
 
 # rt#9939
 traders traders.berkeley.edu - -
+traders traders.studentorg.berkeley.edu - - [noindex]
 
 # rt#9862
 cpunion cpu.berkeley.edu - -
+cpunion cpu.studentorg.berkeley.edu - - [noindex]
 
 # rt#9915
 scec socenvcollective.berkeley.edu - -
+scec socenvcollective.studentorg.berkeley.edu - - [noindex]
 
 # rt#9879
 devops dab.berkeley.edu - -
+devops dab.studentorg.berkeley.edu - - [noindex]
 
 # rt#9852
 pcg phoenix.berkeley.edu - -
+pcg phoenix.studentorg.berkeley.edu - - [noindex]
 
 # rt#9826
 nice niceacappella.berkeley.edu - -
+nice niceacappella.studentorg.berkeley.edu - - [noindex]
 
 # rt#9811
 pickingbrains pickingbrains.berkeley.edu - -
+pickingbrains pickingbrains.studentorg.berkeley.edu - - [noindex]
 
 # rt#9819
 essa essa.berkeley.edu - -
+essa essa.studentorg.berkeley.edu - - [noindex]
 
 # rt#9829
 ihca ihca.berkeley.edu - -
+ihca ihca.studentorg.berkeley.edu - - [noindex]
 
 # rt#11746
 # rt#9821
@@ -228,443 +256,502 @@ ihca ihca.berkeley.edu - -
 
 # in-person
 thaisa thaisa.berkeley.edu - -
+thaisa thaisa.studentorg.berkeley.edu - - [noindex]
 
 # rt#9793
 beeps beeps.berkeley.edu - -
+beeps beeps.studentorg.berkeley.edu - - [noindex]
 
 # rt#9802
 igem igem.berkeley.edu - -
+igem igem.studentorg.berkeley.edu - - [noindex]
 
 # ronit's personal site
 ronitnath ronitnath.com - /com
 
 # rt#9631
 budha budha.berkeley.edu - -
+budha budha.studentorg.berkeley.edu - - [noindex]
 
 # rt#9788
 ioc ioc.berkeley.edu - -
+ioc ioc.studentorg.berkeley.edu - - [noindex]
 
 # rt#9761
-surg surg.berkeley.edu - -
+surg surg.berkeley.edu surg.studentorg.berkeley.edu -
 
 # static discourse archive - development
 staff dev-discourse.ocf.berkeley.edu - /dev-discourse
 
 # rt#9753 :)
-kmoverse kmo.berkeley.edu - -
+kmoverse kmo.berkeley.edu kmo.studentorg.berkeley.edu -
 
 # rt#9727
-calsmv smv.berkeley.edu - -
+calsmv smv.berkeley.edu smv.studentorg.berkeley.edu -
 
 # rt#9686
-amchem acs.berkeley.edu - -
+amchem acs.berkeley.edu acs.studentorg.berkeley.edu -
 
 # rt#9706
 berkstoothfairy berkstoothfairy.berkeley.edu - -
+berkstoothfairy berkstoothfairy.studentorg.berkeley.edu - - [noindex]
 
 # rt#9644
 exsurgo exsurgo.studentorg.berkeley.edu exsurgo.berkeley.edu /final
 
 # rt#9675
 impactinvesting impactinvesting.berkeley.edu - -
+impactinvesting impactinvesting.studentorg.berkeley.edu - - [noindex]
 
 # rt#9643
-surfrider surfrider.berkeley.edu - -
+surfrider surfrider.berkeley.edu surfrider.studentorg.berkeley.edu -
 
 # rt#9580
 e7staff pythonnumericalmethods.berkeley.edu - -
+e7staff pythonnumericalmethods.studentorg.berkeley.edu - - [noindex]
 
 # rt#9618
 prytanean prytanean.berkeley.edu - -
+prytanean prytanean.studentorg.berkeley.edu - - [noindex]
 
 # rt#9566
 amanecer amanecer.berkeley.edu - -
+amanecer amanecer.studentorg.berkeley.edu - - [noindex]
 
 # rt#9525
 sportsmed sportsmed.berkeley.edu - -
+sportsmed sportsmed.studentorg.berkeley.edu - - [noindex]
 
 # rt#9543
-asucsteam asucsteam.berkeley.edu - -
+asucsteam asucsteam.berkeley.edu asucsteam.studentorg.berkeley.edu -
 
 # rt#9544
 psab psychedelicscience.berkeley.edu - -
+psab psychedelicscience.studentorg.berkeley.edu - - [noindex]
 
 # rt#9511
 mcgc mcgc.berkeley.edu - -
+mcgc mcgc.studentorg.berkeley.edu - - [noindex]
 
 # rt#9500
 consulting cschool.berkeley.edu - -
+consulting cschool.studentorg.berkeley.edu - - [noindex]
 
 # rt#9480
-deltaconsulting delta.berkeley.edu - -
+deltaconsulting delta.berkeley.edu delta.studentorg.berkeley.edu -
 
 # rt#9479
-cribb cribb.berkeley.edu - -
+cribb cribb.berkeley.edu cribb.studentorg.berkeley.edu -
 
 # rt#9447
-elchoi whale.berkeley.edu - -
+elchoi whale.berkeley.edu whale.studentorg.berkeley.edu -
 
 # rt#9442
 bcsp bcsp.berkeley.edu psychedelics.berkeley.edu -
 
 # added 2020-08-19 wqnguyen rt#9399
 tiffanyjyu hpa101.berkeley.edu - -
+tiffanyjyu hpa101.studentorg.berkeley.edu - - [noindex]
 
 # added 2020-08-18 wqnguyen rt#9400
 otd otd.berkeley.edu - -
+otd otd.studentorg.berkeley.edu - - [noindex]
 
 # rt#9393
-ecode ecode.berkeley.edu - -
+ecode ecode.berkeley.edu ecode.studentorg.berkeley.edu -
 
 # added 2020-08-14 wqnguyen rt#9383
-ivcf intervarsity.berkeley.edu - -
+ivcf intervarsity.berkeley.edu intervarsity.studentorg.berkeley.edu -
 
 # rt#9328
-legends legends.berkeley.edu - -
+legends legends.berkeley.edu legends.studentorg.berkeley.edu -
 
 # added 2020-07-28 kmo personal email
-ejmp mappingforej.berkeley.edu - -
+ejmp mappingforej.berkeley.edu mappingforej.studentorg.berkeley.edu -
 
 # rt#9252
 # datagood - - -
 
 # rt#9255
-ume ume.berkeley.edu - -
+ume ume.berkeley.edu ume.studentorg.berkeley.edu -
 
 # rt#9247
-simam wim.berkeley.edu - -
+simam wim.berkeley.edu wim.studentorg.berkeley.edu -
 
 # added 2020-06-22 jaw rt#9202
-fsae fsae.berkeley.edu - -
+fsae fsae.berkeley.edu fsae.studentorg.berkeley.edu -
 
 # added 2020-06-16 jaw rt#9172
-gwe gwe.berkeley.edu - -
+gwe gwe.berkeley.edu gwe.studentorg.berkeley.edu -
 
 # added 2020-06-12 minos in-person
 uav theprojectboom.org - /boom
 
 # added 2020-06-12 jaw personal email
 grotech grotech.berkeley.edu - -
+grotech grotech.studentorg.berkeley.edu - - [noindex]
 
 # added 2020-05-31 jaw rt#9130
 launchpad launchpad.berkeley.edu - -
 
 # added 2020-05-22 jaw rt#9106
 connectcal connected.berkeley.edu - -
+connectcal connected.studentorg.berkeley.edu - - [noindex]
 
 # added 2020-05-22 jaw rt#9101
-girlup girlup.berkeley.edu - -
+girlup girlup.berkeley.edu girlup.studentorg.berkeley.edu -
 
 # added 2020-05-20 jaw rt#9087
-srinivasan lcdlab.berkeley.edu - -
+srinivasan lcdlab.berkeley.edu lcdlab.studentorg.berkeley.edu -
 
 # added 2020-05-20 jaw rt#9077
-greenbrk futureadvancers.berkeley.edu - -
+greenbrk futureadvancers.berkeley.edu futureadvancers.studentorg.berkeley.edu -
 
 # added 2020-05-20 jaw rt#9085
 wmb wavemakers.berkeley.edu - -
+wmb wavemakers.studentorg.berkeley.edu - - [noindex]
 
 # added 2020-05-19 jaw rt#9082
 fblapbl pbl.berkeley.edu - -
+fblapbl pbl.studentorg.berkeley.edu - - [noindex]
 
 # added 2020-05-05 njha rt#8837
-ahsleep sleepteam.berkeley.edu - /sleepteam
+ahsleep sleepteam.berkeley.edu sleepteam.studentorg.berkeley.edu /sleepteam
 
 # added 2020-04-29 cooperc rt#9056
 bateuplab bateuplab.berkeley.edu - -
+bateuplab bateuplab.studentorg.berkeley.edu - - [noindex]
 
 # added 2020-04-21 jaw rt#9028
-perennial perennial.berkeley.edu - -
+perennial perennial.berkeley.edu perennial.studentorg.berkeley.edu -
 
 # added 2020-04-19 jaw rt#8997, rt#9021
-bamlab bamlab.berkeley.edu - -
+bamlab bamlab.berkeley.edu bamlab.studentorg.berkeley.edu -
 
 # added 2020-04-17 jaw rt#8927
-shack shac.berkeley.edu - -
+shack shac.berkeley.edu shac.studentorg.berkeley.edu -
 
 # added 2020-04-15 jaw rt#9007
 tassellink tassellink.berkeley.edu - -
+tassellink tassellink.studentorg.berkeley.edu - - [noindex]
 
 # added 2020-04-11 jaw rt#8999
 openpapr openpapr.berkeley.edu - -
+openpapr openpapr.studentorg.berkeley.edu - - [noindex]
 
 # added 2020-03-31 jaw rt#8979
 cinebears cinebears.berkeley.edu - -
+cinebears cinebears.studentorg.berkeley.edu - - [noindex]
 
 # added 2020-03-01 minos in-person
-auvs urobotics.berkeley.edu - -
+auvs urobotics.berkeley.edu urobotics.studentorg.berkeley.edu -
 
 # added 2020-02-24 snarain in-person
 plextech plextech.berkeley.edu - -
 
 # added 2020-02-22 jaw rt#8857
 skynx skynx.berkeley.edu - -
+skynx skynx.studentorg.berkeley.edu - - [noindex]
 
 # added 2020-02-16 cooperc rt#8807
-alzheimers alzassociation.berkeley.edu - -
+alzheimers alzassociation.berkeley.edu alzassociation.studentorg.berkeley.edu -
 
 # added 2020-02-06 jaw rt#8804
-boaa boaa.berkeley.edu - -
+boaa boaa.berkeley.edu boaa.studentorg.berkeley.edu -
 
 # added 2020-02-05 kmo rt#8790
 datastory datastory.berkeley.edu - -
+datastory datastory.studentorg.berkeley.edu - - [noindex]
 
 # added 2020-02-03 cooperc in-person
-issues bmj.berkeley.edu - -
+issues bmj.berkeley.edu bmj.studentorg.berkeley.edu -
 
 #added 2020-01-25 jaw rt#8727
-asbmb asbmb.berkeley.edu - -
+asbmb asbmb.berkeley.edu asbmb.studentorg.berkeley.edu -
 
 # added 2020-01-24 bernardzhao in-person
 # updated cooperc
 # added jaw
 techsocialimpact tsihacks.berkeley.edu - /ImpactHacksWebsite
+techsocialimpact tsihacks.studentorg.berkeley.edu - /ImpactHacksWebsite [noindex]
 techsocialimpact tsi.berkeley.edu - /ClubWebsite
+techsocialimpact tsi.studentorg.berkeley.edu - /ClubWebsite [noindex]
 
 # added 2020-01-22 cooperc rt#8760
-movefellowship movefellowship.berkeley.edu - -
+movefellowship movefellowship.berkeley.edu movefellowship.studentorg.berkeley.edu -
 
 # added 2019-11-18 jaw rt#8673
 bbi bbi.berkeley.edu - -
+bbi bbi.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-11-06 jaw rt#8652
 arrc menarrc.berkeley.edu - -
+arrc menarrc.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-10-27 fydai rt#8610
-rics rics.berkeley.edu - -
+rics rics.berkeley.edu rics.studentorg.berkeley.edu -
 
 # added 2019-10-21 cooperc in-person
 sro sro.berkeley.edu - -
+sro sro.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-10-19 longlian in-person
-bcssa bcssa.berkeley.edu - -
+bcssa bcssa.berkeley.edu bcssa.studentorg.berkeley.edu -
 
 # added 2019-09-28 rachy rt#8540
-threedma 3dma.berkeley.edu - -
+threedma 3dma.berkeley.edu 3dma.studentorg.berkeley.edu -
 
 # added 2019-09-23 cooperc rt#8520
 bigdata bd.berkeley.edu - -
+bigdata bd.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-09-13 fydai in-person
-calcanoe concretecanoe.berkeley.edu - -
+calcanoe concretecanoe.berkeley.edu concretecanoe.studentorg.berkeley.edu -
 
 # added 2019-09-09 minos in-person
 uav aerobear.berkeley.edu - /aerobear
+uav aerobear.studentorg.berkeley.edu - /aerobear [noindex]
 
 # added 2019-09-05 abizer rt#8488
 behr behr.cchem.berkeley.edu - -
+behr behr.cchem.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-09-04 johnxinyu rt#8477
 forchristssake forchristssake.berkeley.edu - -
+forchristssake forchristssake.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-09-04 ethanhs in-person
 #lagses - - -
 
 # added 2019-09-02 jaw rt#8471
 sdb parli.berkeley.edu - -
+sdb parli.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-08-30 bdriscoll rt#8434
-janengelmann socialorigins.berkeley.edu - -
+janengelmann socialorigins.berkeley.edu socialorigins.studentorg.berkeley.edu -
 
 # added 2019-08-28 abizer rt#8445
 rcs rcsa.berkeley.edu - -
+rcs rcsa.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-08-22 abizer rt#8425
-ahf assyrian.berkeley.edu - -
+ahf assyrian.berkeley.edu assyrian.studentorg.berkeley.edu -
 
 # added 2019-08-17 fydai rt#8410
 # mcbtutoring mcb102tutoring - /102
 # 2020-03-02 cooperc rt#8883
 mcbtutoring mcbtutoring.berkeley.edu mcb102tutoring.berkeley.edu -
+mcbtutoring mcbtutoring.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-08-16 abizer rt#8414
-rccohen cohen.cchem.berkeley.edu - -
+rccohen cohen.cchem.berkeley.edu cohen.cchem.studentorg.berkeley.edu -
 
 # added 2019-08-08 abizer in-person
 rreg rreg.berkeley.edu - -
+rreg rreg.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-07-27 ning rt#8327
-sljohnson calm.berkeley.edu - -
+sljohnson calm.berkeley.edu calm.studentorg.berkeley.edu -
 
 # added 2019-06-17 jaw rt#8330
-dronkers aphasia.berkeley.edu - -
+dronkers aphasia.berkeley.edu aphasia.studentorg.berkeley.edu -
 
 # added 2019-06-13 asai rt#8327
 crommie crommie.berkeley.edu - -
+crommie crommie.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-06-08 keur in-person
 animedestiny calanimedestiny.com - -
 
 # added 2019-05-16 keur in-person
-aurum aurum.berkeley.edu - -
+aurum aurum.berkeley.edu aurum.studentorg.berkeley.edu -
 
 # added 2019-05-15 ethanhs rt#8281
 iosdev iosdev.berkeley.edu - -
+iosdev iosdev.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-05-09 abizer rt#8266
 bcci bcci.me.berkeley.edu bcci.berkeley.edu -
+bcci bcci.me.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-05-08 ? ?
-qarc queer.berkeley.edu - -
+qarc queer.berkeley.edu queer.studentorg.berkeley.edu -
 
 # added 2019-05-05 keur in-person
 ucbmun bearmun.berkeley.edu - /bearmun-site
+ucbmun bearmun.studentorg.berkeley.edu - /bearmun-site [noindex]
 
 # added 2019-05-01 dkessler rt#8214
-bisl bisl.berkeley.edu - -
+bisl bisl.berkeley.edu bisl.studentorg.berkeley.edu -
 
 # added 2019-05-01 keur in-person
 # Make animage.berkeley.edu not redirect to cal.moe
 animage cal.moe calanimagealpha.com -
 animage animage.berkeley.edu - -
+animage animage.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-04-25 cooperc rt#8216
 jhuelsenbeck rev-scripter.com - -
 
 # added 2019-04-25 abizer rt#8232
-espm espm50ac.berkeley.edu - -
+espm espm50ac.berkeley.edu espm50ac.studentorg.berkeley.edu -
 
 # added 2019-04-22 keur in-person
-soga soga.berkeley.edu - /wordpress
+soga soga.berkeley.edu soga.studentorg.berkeley.edu /wordpress
 
 # added 2019-04-20 ethanhs rt#8219
-businessreview businessreview.berkeley.edu - -
+businessreview businessreview.berkeley.edu businessreview.studentorg.berkeley.edu -
 
 # added 2019-04-17 dkessler rt#8206
-grounduptheater walls.berkeley.edu - -
+grounduptheater walls.berkeley.edu walls.studentorg.berkeley.edu -
 
 # added 2019-04-12 cooperc rt#8190
-vexu vexu.berkeley.edu - -
+vexu vexu.berkeley.edu vexu.studentorg.berkeley.edu -
 
 # added 2019-04-11 abizer rt#8171
 bridges bridges.berkeley.edu - -
+bridges bridges.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-04-11 abizer rt#8186
-cedgasu cedgasu.berkeley.edu - -
+cedgasu cedgasu.berkeley.edu cedgasu.studentorg.berkeley.edu -
 
 # added 2019-04-10 dkessler rt#8075
 # removed by user request 2020-06-20 minos in-person
 # uav autocal - /autocal
 
 # added 2019-04-02 wporr in-person
-toppa toppa.berkeley.edu - -
+toppa toppa.berkeley.edu toppa.studentorg.berkeley.edu -
 
 # added 2019-04-02 abizer rt#8123
 giamag giamag.berkeley.edu - -
+giamag giamag.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-03-26 abizer rt#8141
-bre bre.berkeley.edu - -
+bre bre.berkeley.edu bre.studentorg.berkeley.edu -
 
 # added 2019-03-26 abizer rt#8140
-aminor aminor.mse.berkeley.edu - -
+aminor aminor.mse.berkeley.edu aminor.mse.studentorg.berkeley.edu -
 
 # added 2019-03-15 abizer rt#8114
-cahpsa cahpsa.berkeley.edu - -
+cahpsa cahpsa.berkeley.edu cahpsa.studentorg.berkeley.edu -
 
 # added 2019-03-15 abizer rt#8107
-invent inventabroad.berkeley.edu - -
+invent inventabroad.berkeley.edu inventabroad.studentorg.berkeley.edu -
 
 # added 2019-03-15 abizer rt#8112
 scuba scubadive.berkeley.edu - -
+scuba scubadive.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-03-14 abizer rt#8111
 cmrwg bmrc.berkeley.edu - -
 
 # added 2019-03-13 dkessler in-person
 reach reach.berkeley.edu - -
+reach reach.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-03-04 dkessler rt#8053
 bioehs officerwiki-bioehs.berkeley.edu - /officerwiki
+bioehs officerwiki-bioehs.studentorg.berkeley.edu - /officerwiki [noindex]
 
 # added 2019-03-03 dkessler rt#8068
 kdsap kdsap.berkeley.edu - -
+kdsap kdsap.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-02-23 dkessler rt#8051
 mri mri.berkeley.edu - -
+mri mri.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-02-21 keur in-person
 #hyperloop - - -
 # added 2020-01-22 cooperc in-person
-hyperloop ev.berkeley.edu - -
+hyperloop ev.berkeley.edu ev.studentorg.berkeley.edu -
 
 # added 2019-02-20 dkessler rt#8040
-hurling hurling.berkeley.edu - -
+hurling hurling.berkeley.edu hurling.studentorg.berkeley.edu -
 
 # added 2019-02-15 cooperc rt#8003
 #robertoloconte - - -
 
 # added 2019-02-08 cooperc rt#8008
-ppilipinx p4.berkeley.edu - -
+ppilipinx p4.berkeley.edu p4.studentorg.berkeley.edu -
 
 # added 2019-02-05 dkessler rt#7986
 opensource opensource.berkeley.edu - -
+opensource opensource.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-02-02 dkessler rt#7993
-giant giantfilmmakers.berkeley.edu - -
+giant giantfilmmakers.berkeley.edu giantfilmmakers.studentorg.berkeley.edu -
 
 # added 2019-02-01 cooperc in-person
-history phat.berkeley.edu - -
+history phat.berkeley.edu phat.studentorg.berkeley.edu -
 
 # added 2019-02-01 dkessler rt#7990
 linwilbrecht wilbrecht.org - -
 
 # added 2019-01-30 dkessler rt#7929
 bioehs wiki-bioehs.berkeley.edu - /wiki
+bioehs wiki-bioehs.studentorg.berkeley.edu - /wiki [noindex]
 
 # added 2019-01-23 dkessler rt#7961
-laya laya.berkeley.edu - -
+laya laya.berkeley.edu laya.studentorg.berkeley.edu -
 
 # added 2019-01-22 cooperc rt#7951
-pcs pcs.berkeley.edu - -
+pcs pcs.berkeley.edu pcs.studentorg.berkeley.edu -
 
 # added 2019-01-21 abizer rt#7950
 beyond beyondacademia.berkeley.edu - -
+beyond beyondacademia.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-01-16 abizer rt#7939
-hcg hcg.berkeley.edu - -
+hcg hcg.berkeley.edu hcg.studentorg.berkeley.edu -
 
 # added 2019-01-15 abizer rt#7927
 qtsab qtsab.berkeley.edu - -
+qtsab qtsab.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-01-14 dkessler rt#7924
-chrisdmccoy prototype.berkeley.edu - -
+chrisdmccoy prototype.berkeley.edu prototype.studentorg.berkeley.edu -
 
 # added 2019-01-11 seanvernon rt#7921
 ucbmun mun.berkeley.edu - -
+ucbmun mun.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-01-09 dkessler rt#7913
 upe upe.berkeley.edu upe.cs.berkeley.edu -
+upe upe.studentorg.berkeley.edu - - [noindex]
 
 # added 2019-01-08 dkessler rt#7908
 # deleted rt#9294
 # capclub - - -
 
 # added 2018-12-22 dkessler rt#7893
-choofnagle hoofnagle.berkeley.edu - -
+choofnagle hoofnagle.berkeley.edu hoofnagle.studentorg.berkeley.edu -
 choofnagle denialism.com - /denialism
 # added 2020-03-09 jaw rt#8848
-choofnagle cybears.berkeley.edu - /cybears
+choofnagle cybears.berkeley.edu cybears.studentorg.berkeley.edu /cybears
 
 # added 2018-12-17 dkessler rt#7885
-tbrooks ceri.berkeley.edu - -
+tbrooks ceri.berkeley.edu ceri.studentorg.berkeley.edu -
 
 # added 2018-12-09 abizer rt#7873
-bearwolf bgb.berkeley.edu - -
+bearwolf bgb.berkeley.edu bgb.studentorg.berkeley.edu -
 
 # added 2018-12-03 abizer rt#7857
 barestge barestage.berkeley.edu - -
+barestge barestage.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-12-02 dkessler rt#7854
-thegolden thegolden.berkeley.edu - -
+thegolden thegolden.berkeley.edu thegolden.studentorg.berkeley.edu -
 
 # added 2018-11-30 mdcha in-person ASUC stuff
 asucdev news.asuc.org - /news2
 
 # added 2018-11-16 dkessler rt#7818
 databears db.berkeley.edu - -
+databears db.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-11-07 dkessler rt#7786
-ispe ispe.berkeley.edu - -
+ispe ispe.berkeley.edu ispe.studentorg.berkeley.edu -
 
 # added 2018-10-23 abizer rt#7696
 # not to activate until vhost compliant with policies
@@ -672,187 +759,218 @@ ispe ispe.berkeley.edu - -
 
 # added 2018-11-05 dkessler rt#7766
 ahub thaqalayn.berkeley.edu - -
+ahub thaqalayn.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-11-05 dkessler rt#7765
 seealso seealso.berkeley.edu - -
+seealso seealso.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-10-28 dkessler rt#7712
-breathe breathe.berkeley.edu - -
+breathe breathe.berkeley.edu breathe.studentorg.berkeley.edu -
 
 # added 2018-10-26 dkessler rt#7707
-foster fosterlab.berkeley.edu - -
+foster fosterlab.berkeley.edu fosterlab.studentorg.berkeley.edu -
 
 # added 2018-10-23 keur in-person
-glob glo.berkeley.edu - -
+glob glo.berkeley.edu glo.studentorg.berkeley.edu -
 
 # added 2018-10-22 abizer rt#7688
 # migrated from earlier rsp vhost config
-rsp rsspsustainability.berkeley.edu rsp.berkeley.edu -
+rsp rsspsustainability.berkeley.edu rsp.berkeley.edu,rsspsustainability.studentorg.berkeley.edu -
 
 # added 2018-10-22 abizer rt#7695
 sportsanalytics sportsanalytics.berkeley.edu - -
+sportsanalytics sportsanalytics.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-10-18 mdcha in-person
-brb bail.berkeley.edu - -
+brb bail.berkeley.edu bail.studentorg.berkeley.edu -
 
 # added 2018-10-116 dkessler rt#7684
-prb policyreview.berkeley.edu - -
+prb policyreview.berkeley.edu policyreview.studentorg.berkeley.edu -
 
 # added 2018-10-15 dkessler rt#7657
-bdrt bdt.berkeley.edu - -
+bdrt bdt.berkeley.edu bdt.studentorg.berkeley.edu -
 
 # added 2018-10-15 keur rt#7662
-ugcc ugcc.berkeley.edu - -
+ugcc ugcc.berkeley.edu ugcc.studentorg.berkeley.edu -
 
 # added 2018-10-12 cooperc in-person
 pvc calprevet.berkeley.edu - -
+pvc calprevet.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-10-04 abizer rt#7641
 bapscampus bcf.berkeley.edu - -
+bapscampus bcf.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-09-27 mdcha in-person
 bicycal bicycal.berkeley.edu - -
+bicycal bicycal.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-09-19 wporr
-amsa amsa.berkeley.edu - -
+amsa amsa.berkeley.edu amsa.studentorg.berkeley.edu -
 
 # added 2018-09-26 dkessler rt#7617
 urec urec.berkeley.edu - -
 
 # added 2018-09-19 mdcha in-person
 neurotech neurotech.berkeley.edu - -
+neurotech neurotech.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-09-18 kpengboy rt#7495
 cubeclub cube.berkeley.edu - -
+cubeclub cube.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-09-01 abizer rt#7542
-circlek cki.berkeley.edu - -
+circlek cki.berkeley.edu cki.studentorg.berkeley.edu -
 
 # added 2018-08-31 abizer rt#7477
 itsdecal introtosurgery.berkeley.edu - -
+itsdecal introtosurgery.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-08-29 abizer rt#7526
-awe awe.berkeley.edu - -
+awe awe.berkeley.edu awe.studentorg.berkeley.edu -
 
 # added 2018-08-22 dkessler rt#7501
-air artistsinresonance.berkeley.edu - -
+air artistsinresonance.berkeley.edu artistsinresonance.studentorg.berkeley.edu -
 
 # added 2018-08-21 abizer rt#7494
 bnni nano.berkeley.edu - -
+bnni nano.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-08-16 abizer rt#7449
 dabestlab edens.berkeley.edu - -
+dabestlab edens.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-07-31 abizer rt#7457
 # ctennis bta - - # not to activate until vhost ready
 
 # added 2018-07-11 keur rt#7405
 idegroup ide.berkeley.edu - -
+idegroup ide.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-07-06 abizer rt#7398
 gacavp untapped.berkeley.edu - -
+gacavp untapped.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-06-18 abizer (private email)
 digitalrefuge digitalrefuge.berkeley.edu - -
+digitalrefuge digitalrefuge.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-06-07 abizer rt#7384
-bremlab bremlab.berkeley.edu - -
+bremlab bremlab.berkeley.edu bremlab.studentorg.berkeley.edu -
 
 # added 2018-05-11 abizer rt#7331
-bamnm bamnm.berkeley.edu - -
+bamnm bamnm.berkeley.edu bamnm.studentorg.berkeley.edu -
 
 # added 2018-05-11 abizer rt#7332
-bii bii.berkeley.edu - -
+bii bii.berkeley.edu bii.studentorg.berkeley.edu -
 
 # added 2018-05-03 abizer rt#7257
 seedofhealth bmri.berkeley.edu - -
+seedofhealth bmri.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-05-01 bzh rt#7294
-construction constructionteam.berkeley.edu - -
+construction constructionteam.berkeley.edu constructionteam.studentorg.berkeley.edu -
 
 # added 2018-04-23 jvperrin (in person)
 hkn hivemind.eecs.berkeley.edu hivemind.berkeley.edu /hivemind
+hkn hivemind.eecs.studentorg.berkeley.edu - /hivemind [noindex]
 
 # added 2018-04-17 kpengboy rt#7271
-uweb uweb.berkeley.edu - -
+uweb uweb.berkeley.edu uweb.studentorg.berkeley.edu -
 
 # added 2018-04-13 abizer rt#7265
-beet thebeet.berkeley.edu - -
+beet thebeet.berkeley.edu thebeet.studentorg.berkeley.edu -
 
 # added 2018-04-09 abizer rt#7256
 sie sie.berkeley.edu - -
+sie sie.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-04-02 abizer rt#7201
 synapse synapse.berkeley.edu - -
 
 # added 2018-03-31 jvperrin rt#6936
 asrg asrg.berkeley.edu - -
+asrg asrg.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-03-19 clhager rt#7177
 goldeneye goldeneye.berkeley.edu - -
+goldeneye goldeneye.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-03-07 jvperrin (in person)
 asuchousing asuchousing.berkeley.edu - -
+asuchousing asuchousing.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-03-06 abizer rt#7160
-madelucchi madelucchi.berkeley.edu - -
+madelucchi madelucchi.berkeley.edu madelucchi.studentorg.berkeley.edu -
 
 # added 2018-03-02 abizer rt#7147
 eatb entrepreneurs.berkeley.edu - -
 
 # added 2018-02-23 abizer rt#7065
 bsjas bsjas.berkeley.edu - -
+bsjas bsjas.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-02-22 abizer rt#7114
-asrb asrb.berkeley.edu - -
+asrb asrb.berkeley.edu asrb.studentorg.berkeley.edu -
 
 # added 2018-02-20 dkessler rt#7074
 utk utk.berkeley.edu - -
+utk utk.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-02-20 vaibhavj rt#7082
 sis southindiansociety.berkeley.edu - -
+sis southindiansociety.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-02-19 abizer rt#7076 - pending fix
 vivecenter vivecenter.berkeley.edu - -
 
 # added 2018-02-13 dkessler rt#7083
-ucbr peace.berkeley.edu - -
+ucbr peace.berkeley.edu peace.studentorg.berkeley.edu -
 
 # added 2018-02-13 abizer rt#7069
 smd smd.berkeley.edu - -
+smd smd.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-02-02 abizer rt#7047
-fitness fitness.berkeley.edu - -
+fitness fitness.berkeley.edu fitness.studentorg.berkeley.edu -
 
 # added 2018-01-29 abizer rt#7024
 ircb ircb.berkeley.edu - -
+ircb ircb.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-01-26 abizer rt#7001 (preemptive)
 # bnni nano - -
 
 # added 2018-01-24 abizer rt#7006
 rjp plevin.berkeley.edu - -
+rjp plevin.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-01-24 abizer rt#7007
 chec chec.berkeley.edu - -
+chec chec.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-01-23 jvperrin rt#6990
 pgrigas grigas.ieor.berkeley.edu - -
+pgrigas grigas.ieor.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-01-22 jvperrin rt#6939
 # modified 2018-02-07 jvperrin (in person) to add neurolab alias
 # They are switching over to a new group name, so we should remove
 # neri.berkeley.edu at the end of this semester (~2018-05)
-neri neurolab.berkeley.edu neri -
+neri neurolab.berkeley.edu neri,neurolab.studentorg.berkeley.edu -
 
 # added 2018-01-21 abizer rt#6980
 berkeleet berke1337.berkeley.edu - -
+berkeleet berke1337.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-01-21 kuoh rt#6979
 bab bab.berkeley.edu - -
+bab bab.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-01-20 abizer rt#6972
 qcb qcb.berkeley.edu - -
+qcb qcb.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-01-17 abizer rt#6958
 kweiner cnl.berkeley.edu - -
@@ -862,107 +980,120 @@ kweiner cnl.berkeley.edu - -
 # remove the gamecraft alias at the end of
 # the fall 2018 semester.
 gamecraft gamedesign.berkeley.edu gamecraft.berkeley.edu -
+gamecraft gamedesign.studentorg.berkeley.edu - - [noindex]
 
 # added 2018-01-14 abizer rt#6948
-caldboat caldragonboat.berkeley.edu - -
+caldboat caldragonboat.berkeley.edu caldragonboat.studentorg.berkeley.edu -
 
 # added 2018-01-11 abizer rt#6943
-caltv caltv.berkeley.edu - -
+caltv caltv.berkeley.edu caltv.studentorg.berkeley.edu -
 
 # added 2018-01-11 abizer rt#6935
 boblev bpl.berkeley.edu - -
+boblev bpl.studentorg.berkeley.edu - - [noindex]
 
 # added 2017-12-29 abizer rt#6922
-sather satherhealth.berkeley.edu - -
+sather satherhealth.berkeley.edu satherhealth.studentorg.berkeley.edu -
 
 # added 2017-12-24 abizer rt#6874
-calite ite.berkeley.edu - -
+calite ite.berkeley.edu ite.studentorg.berkeley.edu -
 
 # added 2017-12-20 abizer rt#6914
 stephenepa palmerlab.berkeley.edu - -
+stephenepa palmerlab.studentorg.berkeley.edu - - [noindex]
 
 # re-added 2017-12-18 abizer
 # Commented out 2018-07-17 jvperrin (on a different server now)
 decal decal.ocf.berkeley.edu decal.ocf.io,decal.xcf.sh,decal.xcf.berkeley.edu -
 
 # added 2017-12-18 abizer rt#6908
-kring esilab.berkeley.edu - -
+kring esilab.berkeley.edu esilab.studentorg.berkeley.edu -
 
 # added 2017-12-14 abizer rt#6886
-sciencepolicy sciencepolicy.berkeley.edu - -
+sciencepolicy sciencepolicy.berkeley.edu sciencepolicy.studentorg.berkeley.edu -
 
 # added 2017-12-06 abizer rt#6868
-tsrg tsrg.berkeley.edu thinkoutsidethebox.berkeley.edu -
+tsrg tsrg.berkeley.edu thinkoutsidethebox.berkeley.edu,tsrg.studentorg.berkeley.edu -
 
 # added 2017-12-01 keur rt#6878
-bhi bhi.berkeley.edu - -
+bhi bhi.berkeley.edu bhi.studentorg.berkeley.edu -
 
 # added 2017-12-01 keur rt#6877
 datapeers datapeers.berkeley.edu - -
+datapeers datapeers.studentorg.berkeley.edu - - [noindex]
 
 # added 2017-11-29 keur rt#6845
-bioprinting bioprinting.berkeley.edu - -
+bioprinting bioprinting.berkeley.edu bioprinting.studentorg.berkeley.edu -
 
 # added 2017-11-29 chuang rt#6863
-moveme moveme.berkeley.edu - -
+moveme moveme.berkeley.edu moveme.studentorg.berkeley.edu -
 
 # added 2017-11-14 abizer rt#6812
-bppj bppj.berkeley.edu - -
+bppj bppj.berkeley.edu bppj.studentorg.berkeley.edu -
 
 # added 2017-11-13 abizer rt#6810
-isa isa.berkeley.edu - -
+isa isa.berkeley.edu isa.studentorg.berkeley.edu -
 
 # added 2017-11-09 jvperrin
-hkn prot-hkn.eecs.berkeley.edu prot.hkn.mu /wiki
+hkn prot-hkn.eecs.berkeley.edu prot.hkn.mu,prot-hkn.eecs.studentorg.berkeley.edu /wiki
 
 # added 2017-10-19 abizer rt#6682
 gdso gdso.berkeley.edu - -
+gdso gdso.studentorg.berkeley.edu - - [noindex]
 
 # added 2017-10-17 abizer rt#6667
 # thanks LSIT for telling us about this
 jhti jhti.berkeley.edu - -
+jhti jhti.studentorg.berkeley.edu - - [noindex]
 
 # added 2017-10-17 abizer rt#6667
 gregniemeyer mfa.berkeley.edu - -
+gregniemeyer mfa.studentorg.berkeley.edu - - [noindex]
 
 # added 2017-10-14 abizer rt#6662
 efork e4k.berkeley.edu - -
+efork e4k.studentorg.berkeley.edu - - [noindex]
 
 # added 2017-10-04 abizer rt#6639
 mtab mtab.berkeley.edu - -
+mtab mtab.studentorg.berkeley.edu - - [noindex]
 
 # added 2017-09-22 abizer rt#6607
-pha pha.berkeley.edu - -
+pha pha.berkeley.edu pha.studentorg.berkeley.edu -
 
 # added 2017-09-16 kpengboy
 # would be nice to use the ofc account for this, but it would have to be
 # unsorried to work properly :(
 staff ofc.berkeley.edu - /ofc
+staff ofc.studentorg.berkeley.edu - /ofc [noindex]
 
 # added 2017-09-13 abizer rt#6550
-oceansociety oceansociety.berkeley.edu - -
+oceansociety oceansociety.berkeley.edu oceansociety.studentorg.berkeley.edu -
 
 # added 2017-09-12 abizer rt#6497
-ink ink.eecs.berkeley.edu - -
+ink ink.eecs.berkeley.edu ink.eecs.studentorg.berkeley.edu -
 
 # added 2017-09-08 abizer rt#6527
 eswb esw.berkeley.edu - -
+eswb esw.studentorg.berkeley.edu - - [noindex]
 
 # added 2017-09-07 abizer rt#6530
-vsa vsa.berkeley.edu - -
+vsa vsa.berkeley.edu vsa.studentorg.berkeley.edu -
 
 # added 2017-09-06 abizer rt#6526
-rdoc gseresearchday.berkeley.edu - -
+rdoc gseresearchday.berkeley.edu gseresearchday.studentorg.berkeley.edu -
 
 # added 2017-09-06 abizer rt#6525
 simp secondimpressions.berkeley.edu - -
+simp secondimpressions.studentorg.berkeley.edu - - [noindex]
 
 # added 2017-09-05 abizer rt#6519
-lightweightcrew lightweightcrew.berkeley.edu - -
+lightweightcrew lightweightcrew.berkeley.edu lightweightcrew.studentorg.berkeley.edu -
 # added 2019-02-13 cooperc rt#8010 (name change)
 # note: ideally lightweightcrew.berkeley.edu should be disabled after a
 # sufficient transition period to the new domain
 lightweightcrew lightweightrowing.berkeley.edu - /wp
+lightweightcrew lightweightrowing.studentorg.berkeley.edu - /wp [noindex]
 
 # added 2017-08-31 abizer rt#6491
 # Commenting this out because the domain name got bought by a porn company
@@ -970,22 +1101,25 @@ lightweightcrew lightweightrowing.berkeley.edu - /wp
 
 # [added 2017-08-12 abizer rt#6415]
 # presumably they'll want the account name changed in the future as well
-sinmaysa ssa.berkeley.edu smsa.berkeley.edu -
+sinmaysa ssa.berkeley.edu smsa.berkeley.edu,ssa.studentorg.berkeley.edu -
 
 # [added 2017-08-10 kpengboy rt#6414]
 sopi sopi.berkeley.edu - -
+sopi sopi.studentorg.berkeley.edu - - [noindex]
 
 # [added 2017-08-09 abizer rt#6412]
 acollins ccn.berkeley.edu - -
+acollins ccn.studentorg.berkeley.edu - - [noindex]
 
 # [added 2017-08-08 abizer rt#6402]
-keltner bsil.berkeley.edu - -
+keltner bsil.berkeley.edu bsil.studentorg.berkeley.edu -
 
 # [added 2017-07-24 abizer rt#6378]
 iie iise.berkeley.edu iie.berkeley.edu -
 
 # [added 2017.07.12 jvperrin]
 ushp ushp.berkeley.edu - -
+ushp ushp.studentorg.berkeley.edu - - [noindex]
 
 # projectscifi vhosts deactivated by abizer
 # on 2018-12-16 because they've been moved
@@ -1001,7 +1135,7 @@ ushp ushp.berkeley.edu - -
 # royf schoolproject - -
 
 # [added 2017.06.19 mattmcal]
-kadir 157ac.berkeley.edu - -
+kadir 157ac.berkeley.edu 157ac.studentorg.berkeley.edu -
 
 # [added 2017.04.17 abizer]
 # removed 2019-05-13 abizer rt#8276
@@ -1009,49 +1143,56 @@ kadir 157ac.berkeley.edu - -
 
 # [added 2017.04.05 jvperrin]
 helios helios.berkeley.edu - -
+helios helios.studentorg.berkeley.edu - - [noindex]
 
 # [added 2017.03.22 mattmcal]
 foodinno foodinno.berkeley.edu - -
+foodinno foodinno.studentorg.berkeley.edu - - [noindex]
 
 # [added 2017.03.14 abizer]
 dssb dss.berkeley.edu - -
+dssb dss.studentorg.berkeley.edu - - [noindex]
 
 # [added 2017.03.10 kpengboy]
-donut donut.berkeley.edu - -
+donut donut.berkeley.edu donut.studentorg.berkeley.edu -
 
 # [added 2017.03.09 jvperrin]
-memssa memssa.berkeley.edu - -
+memssa memssa.berkeley.edu memssa.studentorg.berkeley.edu -
 
 # [added 2017.03.06 kpengboy]
-bridgeyear bridgeyear.berkeley.edu - -
+bridgeyear bridgeyear.berkeley.edu bridgeyear.studentorg.berkeley.edu -
 
 # [added 2017.02.25 ckuehl]
 pmatb pmatb.berkeley.edu - -
+pmatb pmatb.studentorg.berkeley.edu - - [noindex]
 
 # [added 2017-02-24 kuoh]
 vhio calvhio.org www.calvhio.org -
 
 # [added 2017-02-23 ckuehl]
-rtsa rtsa.berkeley.edu - -
+rtsa rtsa.berkeley.edu rtsa.studentorg.berkeley.edu -
 
 # [added 2017-02-18 jvperrin]
-ugscced cedugsc.berkeley.edu - -
+ugscced cedugsc.berkeley.edu cedugsc.studentorg.berkeley.edu -
 
 # [added 2017-02-13 jvperrin]
-gmb gradmedieval.berkeley.edu - -
+gmb gradmedieval.berkeley.edu gradmedieval.studentorg.berkeley.edu -
 
 # [added 2017-01-17 abizer]
-vmo vmo.berkeley.edu - -
+vmo vmo.berkeley.edu vmo.studentorg.berkeley.edu -
 
 # [added 2016.12.22 jvperrin]
 codebase codebase.berkeley.edu - -
+codebase codebase.studentorg.berkeley.edu - - [noindex]
 
 # [added 2016.11.28 nickimp]
 ptps ptps.berkeley.edu - -
+ptps ptps.studentorg.berkeley.edu - - [noindex]
 
 # [added 2016.11.14 ckuehl]
 staff xkcd.ocf.berkeley.edu xkcd.berkeley.edu /xkcd
 staff freefood.berkeley.edu - /freefood
+staff freefood.studentorg.berkeley.edu - /freefood [noindex]
 
 # [added 2016.11.08 mattmcal]
 # [disabled 2018-01-23 jvperrin, bad DNS, pointing to GitHub pages]
@@ -1059,16 +1200,18 @@ staff freefood.berkeley.edu - /freefood
 
 # [added 2016.10.29 nickimp]
 makerspace makerspace.berkeley.edu - -
+makerspace makerspace.studentorg.berkeley.edu - - [noindex]
 
 # [added 2016.10.25 kpengboy]
 # [disabled 2018-01-23 jvperrin, moved to apphost in rt#6307]
 #stac - - -
 
 # [added 2016.10.21 ckuehl]
-ohsi ohsi.berkeley.edu - -
+ohsi ohsi.berkeley.edu ohsi.studentorg.berkeley.edu -
 
 # [added 2016.10.20 ckuehl]
 gonglab gonglab.berkeley.edu - -
+gonglab gonglab.studentorg.berkeley.edu - - [noindex]
 
 # [added 2016.10.19 mattmcal]
 # [moved 2017.07.24 mattmcal]
@@ -1077,6 +1220,7 @@ asuccfo cfo.asuc.org www.cfo.asuc.org -
 
 # [added 2016.10.17 kpengboy]
 robobears robobears.berkeley.edu - -
+robobears robobears.studentorg.berkeley.edu - - [noindex]
 
 # [added 2016.10.14 kpengboy]
 cao accountability.asuc.org www.accountability.asuc.org -
@@ -1085,85 +1229,97 @@ cao accountability.asuc.org www.accountability.asuc.org -
 staff hello.ocf.io - /hello [hsts]
 
 # [added 2016.10.10 nickimp]
-breadclub bread.berkeley.edu - -
+breadclub bread.berkeley.edu bread.studentorg.berkeley.edu -
 
 # [added 2016.09.30 mattmcal]
 srhwg socialresearchonhealthcare.berkeley.edu - -
+srhwg socialresearchonhealthcare.studentorg.berkeley.edu - - [noindex]
 
 # [added 2016.09.19 mattmcal]
-unicef unicef.berkeley.edu - -
+unicef unicef.berkeley.edu unicef.studentorg.berkeley.edu -
 
 # [added 2016.09.14 mattmcal]
-mcbcdna mcbcdna.berkeley.edu - -
+mcbcdna mcbcdna.berkeley.edu mcbcdna.studentorg.berkeley.edu -
 
 # [added 2016.09.14 mattmcal]
 morningsignout morningsignout.berkeley.edu - -
+morningsignout morningsignout.studentorg.berkeley.edu - - [noindex]
 
 # [added 2016.09.14 mattmcal]
 calslam calslam.org www.calslam.org -
 
 # [added 2016.09.08 jvperrin]
 carillon bells.berkeley.edu - -
+carillon bells.studentorg.berkeley.edu - - [noindex]
 
 # [added 2016.09.03 ckuehl]
-ada ada.berkeley.edu - -
+ada ada.berkeley.edu ada.studentorg.berkeley.edu -
 
 # [added 2016.09.02 ckuehl]
-asae asae.berkeley.edu - -
+asae asae.berkeley.edu asae.studentorg.berkeley.edu -
 
 # [added 2016.08.30 ldw]
-humanists humanists.berkeley.edu - -
+humanists humanists.berkeley.edu humanists.studentorg.berkeley.edu -
 
 # [added 2016.08.29 ckuehl]
 solar solardecathlon.berkeley.edu - -
+solar solardecathlon.studentorg.berkeley.edu - - [noindex]
 
 # [added 2016.08.29 mattmcal]
-maboudianlab maboudianlab.berkeley.edu - -
+maboudianlab maboudianlab.berkeley.edu maboudianlab.studentorg.berkeley.edu -
 
 # [added 2016.08.02 mattmcal]
 unrac unrac.berkeley.edu - -
+unrac unrac.studentorg.berkeley.edu - - [noindex]
 
 # [added 2016.07.30 kpengboy]
-alumni casa.berkeley.edu - -
+alumni casa.berkeley.edu casa.studentorg.berkeley.edu -
 
 # [added 2016.07.24 ckuehl]
 songwriting songwriting.berkeley.edu - -
+songwriting songwriting.studentorg.berkeley.edu - - [noindex]
 
 # [added 2016.05.19 ckuehl]
 swps swps.studentorg.berkeley.edu - -
 
 # [added 2016.05.12 mattmcal]
 space stars.berkeley.edu - -
+space stars.studentorg.berkeley.edu - - [noindex]
 
 # [added 2016.04.19 ckuehl]
 linkbayarea link.berkeley.edu - -
+linkbayarea link.studentorg.berkeley.edu - - [noindex]
 
 # [added 2016.04.18 ckuehl]
 asuckp asuctech.berkeley.edu - -
+asuckp asuctech.studentorg.berkeley.edu - - [noindex]
 
 # [added 2016.04.12 ckuehl]
 vcg vcg.berkeley.edu - -
+vcg vcg.studentorg.berkeley.edu - - [noindex]
 
 # [added 2016.03.30 ckuehl]
 dilse ucberkeleydilse.com www.ucberkeleydilse.com -
 
 # [added 2016.03.28 ckuehl]
 chemecar chemecar.berkeley.edu - -
+chemecar chemecar.studentorg.berkeley.edu - - [noindex]
 
 # [added 2016.03.17 mattmcal]
-btc btc.berkeley.edu - -
+btc btc.berkeley.edu btc.studentorg.berkeley.edu -
 
 # [added 2016.03.07 ckuehl]
 calsca calsca.berkeley.edu - -
+calsca calsca.studentorg.berkeley.edu - - [noindex]
 
 # [added 2016.02.17 jvperrin]
-uea econreview.berkeley.edu - -
+uea econreview.berkeley.edu econreview.studentorg.berkeley.edu -
 
 # [added 2016.02.17 ckuehl]
-buj buj.berkeley.edu - -
+buj buj.berkeley.edu buj.studentorg.berkeley.edu -
 
 # [added 2016.02.09 ckuehl]
-mycrobes mycrobes.berkeley.edu - -
+mycrobes mycrobes.berkeley.edu mycrobes.studentorg.berkeley.edu -
 
 # [added 2016.02.06 ckuehl]
 # (moved to apphosting)
@@ -1173,30 +1329,36 @@ mycrobes mycrobes.berkeley.edu - -
 
 # [added 2016.02.04 mattmcal]
 rcsaconf interucconference.berkeley.edu - -
+rcsaconf interucconference.studentorg.berkeley.edu - - [noindex]
 
 # [added 2016.01.29 ckuehl]
 uas ugastrosociety.berkeley.edu - -
+uas ugastrosociety.studentorg.berkeley.edu - - [noindex]
 
 # [added 2016.01.25 ckuehl]
-enablet enabletech.berkeley.edu - -
+enablet enabletech.berkeley.edu enabletech.studentorg.berkeley.edu -
 
 # [added 2016.01.23 mattmcal]
 polo polo.berkeley.edu - -
+polo polo.studentorg.berkeley.edu - - [noindex]
 
 # [added 2016.01.20 mattmcal]
 unab unab.berkeley.edu - -
+unab unab.studentorg.berkeley.edu - - [noindex]
 
 # added 2016.01.16 ckuehl, reactivated 2019-08-13 abizer rt#8407
 datong datong.berkeley.edu - -
+datong datong.studentorg.berkeley.edu - - [noindex]
 
 # [added 2015.12.10 mattmcal]
 hshot hypershot.berkeley.edu - -
+hshot hypershot.studentorg.berkeley.edu - - [noindex]
 
 # [added 2015.12.01 ckuehl], modified 2019-08-28 abizer rt#8446
-bipla privlab.berkeley.edu bipla.berkeley.edu -
+bipla privlab.berkeley.edu bipla.berkeley.edu,privlab.studentorg.berkeley.edu -
 
 # [added 2015.11.23 ckuehl]
-sfac sfac.berkeley.edu - -
+sfac sfac.berkeley.edu sfac.studentorg.berkeley.edu -
 
 # [added 2015.11.16 ckuehl]
 election elections.asuc.org www.elections.asuc.org -
@@ -1214,42 +1376,48 @@ aavp aavp.asuc.org www.aavp.asuc.org -
 
 # [added 2015.11.01 ckuehl]
 mhc mentalhealth.berkeley.edu - -
-salsa salsaatcal.berkeley.edu - -
+mhc mentalhealth.studentorg.berkeley.edu - - [noindex]
+salsa salsaatcal.berkeley.edu salsaatcal.studentorg.berkeley.edu -
 
 # [added 2015.10.21 ckuehl]
 decalweb decal.asuc.org - -
 
 # [added 2015.10.19 kpengboy]
 # uavs alias added 2019-09-23 minos in-person
-uav uav.berkeley.edu uavs.berkeley.edu -
+uav uav.berkeley.edu uavs.berkeley.edu,uav.studentorg.berkeley.edu -
 
 # [added 2015.10.17 mattmcal]
-fec financeandentrepreneurship.berkeley.edu - -
+fec financeandentrepreneurship.berkeley.edu financeandentrepreneurship.studentorg.berkeley.edu -
 
 # [added 2015.10.12 kpengboy]
-analytic aoc.berkeley.edu - -
+analytic aoc.berkeley.edu aoc.studentorg.berkeley.edu -
 
 # [added 2015.10.06 mattmcal]
 # hip hyperloop - -
 
 # [added 2015.10.03 ckuehl]
 robotics rab.berkeley.edu - -
+robotics rab.studentorg.berkeley.edu - - [noindex]
 
 # [added 2015.09.24 ckuehl]
 wsladmin wordsoundlife.berkeley.edu - -
+wsladmin wordsoundlife.studentorg.berkeley.edu - - [noindex]
 
 # [added 2015.09.21 ckuehl]
 foodsci fst.berkeley.edu - -
+foodsci fst.studentorg.berkeley.edu - - [noindex]
 
 # [added 2015.09.15 mattmcal]
 csm csmentors.berkeley.edu csmentors.org -
+csm csmentors.studentorg.berkeley.edu - - [noindex]
 
 # [added 2015.09.13 ckuehl]
 ealcusa ealcusa.berkeley.edu - -
+ealcusa ealcusa.studentorg.berkeley.edu - - [noindex]
 
 # [added 2015.09.02 ckuehl]
-eua eua.berkeley.edu - -
-batc antitrafficking.berkeley.edu - -
+eua eua.berkeley.edu eua.studentorg.berkeley.edu -
+batc antitrafficking.berkeley.edu antitrafficking.studentorg.berkeley.edu -
 
 # [added 2015.08.21 ckuehl]
 asucfp pantry.berkeley.edu pantry.asuc.org,www.pantry.asuc.org -
@@ -1258,7 +1426,7 @@ asucfp pantry.berkeley.edu pantry.asuc.org,www.pantry.asuc.org -
 # asucdm dancemarathon.asuc.org dancemarathon.berkeley.edu,www.dancemarathon.asuc.org -
 
 # [added 2015.08.16 ckuehl]
-presence presence.berkeley.edu - -
+presence presence.berkeley.edu presence.studentorg.berkeley.edu -
 
 # [added 2015.08.01 ckuehl]
 #staff templates.ocf.berkeley.edu templates /templates
@@ -1269,15 +1437,18 @@ presence presence.berkeley.edu - -
 
 # [added 2015.07.27 mattmcal]
 enviro enviroteam.berkeley.edu - -
+enviro enviroteam.studentorg.berkeley.edu - - [noindex]
 
 # [added 2015.07.01 ckuehl]
 squelch squelched.com www.squelched.com -
 
 # [added 2015.06.06 mattmcal]
 dts drawntoscale.berkeley.edu - -
+dts drawntoscale.studentorg.berkeley.edu - - [noindex]
 
 # [added 2015.05.12 ckuehl]
 polish polishclub.berkeley.edu - -
+polish polishclub.studentorg.berkeley.edu - - [noindex]
 
 # [added 2015.05.06 ckuehl]
 # disabled vhost as new leadership wants new vhost
@@ -1294,9 +1465,10 @@ ocfwiki docs.ocf.berkeley.edu - - [hsts]
 
 # [added 2015.03.30 ckuehl]
 optimir optimir.berkeley.edu - -
+optimir optimir.studentorg.berkeley.edu - - [noindex]
 
 # [added 2015.03.25 ckuehl]
-consumer consumer.berkeley.edu - -
+consumer consumer.berkeley.edu consumer.studentorg.berkeley.edu -
 
 # [added 2015.03.19 ckuehl]
 #ode! - - -
@@ -1307,44 +1479,49 @@ consumer consumer.berkeley.edu - -
 
 # [added 2015.03.02 ckuehl]
 bhwa bhwa.berkeley.edu - -
+bhwa bhwa.studentorg.berkeley.edu - - [noindex]
 
 # [added 2015.02.27 ckuehl]
 # [modified 2019.08.28 fydai rt#8441]
 vrab xr.berkeley.edu vr -
+vrab xr.studentorg.berkeley.edu - - [noindex]
 
 # [added 2016.02.11 ckuehl]
-cscc csc.berkeley.edu - -
+cscc csc.berkeley.edu csc.studentorg.berkeley.edu -
 
 # [added 2015.02.04 ckuehl]
 ymm ymm.berkeley.edu - -
-wpower womenempowerment.berkeley.edu - /wordpress
+ymm ymm.studentorg.berkeley.edu - - [noindex]
+wpower womenempowerment.berkeley.edu womenempowerment.studentorg.berkeley.edu /wordpress
 
 # [added 2015.02.03 ckuehl]
-foresite foresight.berkeley.edu - /blog
+foresite foresight.berkeley.edu foresight.studentorg.berkeley.edu /blog
 
 # [added 2015.02.01 ckuehl]
 rohp rohp.berkeley.edu - -
+rohp rohp.studentorg.berkeley.edu - - [noindex]
 
 # [added 2015.01.31 ckuehl]
-physics sps.berkeley.edu - -
+physics sps.berkeley.edu sps.studentorg.berkeley.edu -
 
 # [added 2015.01.26 ckuehl]
-rball racquetball.berkeley.edu - -
+rball racquetball.berkeley.edu racquetball.studentorg.berkeley.edu -
 
 # [added 2015.01.21 ckuehl]
 mcomm mcomm.berkeley.edu - -
+mcomm mcomm.studentorg.berkeley.edu - - [noindex]
 
 # [added 2015.01.15 ckuehl]
-mbn mbn.berkeley.edu - /wordpress
+mbn mbn.berkeley.edu mbn.studentorg.berkeley.edu /wordpress
 
 # [added 2014.12.05 ckuehl]
-eswerdel eswerdelicht.berkeley.edu - -
+eswerdel eswerdelicht.berkeley.edu eswerdelicht.studentorg.berkeley.edu -
 
 # [added 2014.10.24 ckuehl]
-messrsch bioinspiredmaterials.berkeley.edu - /wordpress
+messrsch bioinspiredmaterials.berkeley.edu bioinspiredmaterials.studentorg.berkeley.edu /wordpress
 
 # [added 2014.10.21 nickimp]
-eerlab eerlab.berkeley.edu - -
+eerlab eerlab.berkeley.edu eerlab.studentorg.berkeley.edu -
 
 # [added 2014.10.13 ckuehl]
 ggroup dev-dev-vhost.ocf.berkeley.edu dev-dev-vhost-alias.ocf.berkeley.edu -
@@ -1352,31 +1529,34 @@ ggroup dev-vhost.ocf.berkeley.edu dev-vhost-alias.ocf.berkeley.edu -
 
 # [added 2014.10.12 ckuehl]
 pokemon pkmn.berkeley.edu - -
+pokemon pkmn.studentorg.berkeley.edu - - [noindex]
 
 # [added 2014.10.12 nickimp]
-psichi psichi.berkeley.edu - -
+psichi psichi.berkeley.edu psichi.studentorg.berkeley.edu -
 
 # [added 2014.10.08 ckuehl]
 # disabled: docroot DNE
 # ejc hultprize - /hult
 
 # [added 2014.09.22 ckuehl]
-ppgs fly.berkeley.edu - -
+ppgs fly.berkeley.edu fly.studentorg.berkeley.edu -
 
 # [added 2014.09.22 ckuehl]
 igs igenspectrum.berkeley.edu - -
+igs igenspectrum.studentorg.berkeley.edu - - [noindex]
 
 # [added 2014.09.19 ckuehl]
-llp llp.berkeley.edu - -
+llp llp.berkeley.edu llp.studentorg.berkeley.edu -
 
 # [added 2014.09.12 ckuehl]
-bpp bpp.berkeley.edu - -
+bpp bpp.berkeley.edu bpp.studentorg.berkeley.edu -
 
 # [added 2014.08.21 ckuehl]
-sirhonor sigmaiotarho.berkeley.edu - -
+sirhonor sigmaiotarho.berkeley.edu sigmaiotarho.studentorg.berkeley.edu -
 
 # [added 2014.08.20 ckuehl]
 bsgsa bsgsa.berkeley.edu - -
+bsgsa bsgsa.studentorg.berkeley.edu - - [noindex]
 
 # # [added 2014.08.01 ckuehl]
 # [disabled 10.4.22 out of use]
@@ -1384,9 +1564,10 @@ bsgsa bsgsa.berkeley.edu - -
 
 # [added 2014.07.31 ckuehl]
 cycb cyc.berkeley.edu - -
+cycb cyc.studentorg.berkeley.edu - - [noindex]
 
 # [added 2014.07.25 ckuehl]
-bpeace bodypeace.berkeley.edu - -
+bpeace bodypeace.berkeley.edu bodypeace.studentorg.berkeley.edu -
 
 # [added 2014.07.01 ckuehl] - deactivated abizer 2018-12-16 domain inactive
 # added 2019-01-28 dkessler with new domain
@@ -1395,24 +1576,28 @@ wrugby californiawomensrugby.com - /wordpress
 
 # [added 2014.06.15 ckuehl]
 eyh eyh.berkeley.edu - -
+eyh eyh.studentorg.berkeley.edu - - [noindex]
 
 # [added 2014.04.25 ckuehl]
 calop calop.berkeley.edu - -
+calop calop.studentorg.berkeley.edu - - [noindex]
 
 # [added 2014.04.16 ckuehl]
 ecal ecal.berkeley.edu - -
+ecal ecal.studentorg.berkeley.edu - - [noindex]
 
 # [added 2014.04.14 ckuehl]
 debsoc debate.berkeley.edu - -
+debsoc debate.studentorg.berkeley.edu - - [noindex]
 
 # [added 2014.04.08 ckuehl]
-mlo mlo.berkeley.edu - -
+mlo mlo.berkeley.edu mlo.studentorg.berkeley.edu -
 
 # [added 2014.04.05 ckuehl]
-bitcoin blockchain.berkeley.edu bitcoin.berkeley.edu /wp
+bitcoin blockchain.berkeley.edu bitcoin.berkeley.edu,blockchain.studentorg.berkeley.edu /wp
 
 # [added 2014.04.04 ckuehl]
-datasci datasci.berkeley.edu - -
+datasci datasci.berkeley.edu datasci.studentorg.berkeley.edu -
 
 # [added 2014.02.27 ckuehl]
 # [disabled 2017.11.15 jvperrin, directory no longer exists]
@@ -1420,46 +1605,55 @@ datasci datasci.berkeley.edu - -
 
 # [added 2014.02.23 ckuehl]
 aiche aiche.berkeley.edu - -
+aiche aiche.studentorg.berkeley.edu - - [noindex]
 
 # [added 2014.02.18 ckuehl]
 # cetsa - - -
-ballroom ballroom.berkeley.edu - -
+ballroom ballroom.berkeley.edu ballroom.studentorg.berkeley.edu -
 
 # [added 2014.02.05 ckuehl]
-cgpsa cgpsa.berkeley.edu - -
+cgpsa cgpsa.berkeley.edu cgpsa.studentorg.berkeley.edu -
 
 # [added 2014.01.29 ckuehl]
 dfacal dfa.berkeley.edu - -
+dfacal dfa.studentorg.berkeley.edu - - [noindex]
 calwlp wlp.berkeley.edu - -
+calwlp wlp.studentorg.berkeley.edu - - [noindex]
 
 # [added 2013.11.26 tzhu]
 hpg hpg.berkeley.edu - -
+hpg hpg.studentorg.berkeley.edu - - [noindex]
 
 # [added 2013.11.22 tzhu]
-cabikes ridesforlives.berkeley.edu - /wordpress
+cabikes ridesforlives.berkeley.edu ridesforlives.studentorg.berkeley.edu /wordpress
 nsls nsls.berkeley.edu - -
+nsls nsls.studentorg.berkeley.edu - - [noindex]
 
 # [added 2013.11.09 tzhu]
-diphs innovate.berkeley.edu - -
-rci rightcare.berkeley.edu - /blog
+diphs innovate.berkeley.edu innovate.studentorg.berkeley.edu -
+rci rightcare.berkeley.edu rightcare.studentorg.berkeley.edu /blog
 sesb sesb.berkeley.edu - -
+sesb sesb.studentorg.berkeley.edu - - [noindex]
 
 # [added 2013.10.11 tzhu]
-isac isac.berkeley.edu - -
-bsj bsj.berkeley.edu - -
+isac isac.berkeley.edu isac.studentorg.berkeley.edu -
+bsj bsj.berkeley.edu bsj.studentorg.berkeley.edu -
 
 # [added 2013.10.02 tzhu]
 #sinmaysa smsa - -
 ixic ixic.berkeley.edu - -
+ixic ixic.studentorg.berkeley.edu - - [noindex]
 
 # [added 2013.09.18 tzhu]
 rnd rnd.berkeley.edu - /rndflask
+rnd rnd.studentorg.berkeley.edu - /rndflask [noindex]
 pda pda.berkeley.edu - -
-iysse iysse.berkeley.edu - /blog
-ucbso orchestra.berkeley.edu - -
+pda pda.studentorg.berkeley.edu - - [noindex]
+iysse iysse.berkeley.edu iysse.studentorg.berkeley.edu /blog
+ucbso orchestra.berkeley.edu orchestra.studentorg.berkeley.edu -
 
 # [added 2013.09.06 daradib]
-bilder bilderlab.berkeley.edu - -
+bilder bilderlab.berkeley.edu bilderlab.studentorg.berkeley.edu -
 
 # [added 2013.08.19 daradib]
 # agile - - -
@@ -1469,35 +1663,43 @@ bilder bilderlab.berkeley.edu - -
 
 # [added 2013.05.22 waf]
 ctc ctc.berkeley.edu - -
+ctc ctc.studentorg.berkeley.edu - - [noindex]
 
 # [added 2013.05.01 tzhu]
-nib nib.berkeley.edu - -
+nib nib.berkeley.edu nib.studentorg.berkeley.edu -
 
 # [added 2013.04.23 waf]
 tsa tsa.berkeley.edu - -
+tsa tsa.studentorg.berkeley.edu - - [noindex]
 
 # [added 2013.03.27 daradib]
 csks cs-kickstart.berkeley.edu - -
+csks cs-kickstart.studentorg.berkeley.edu - - [noindex]
 
 # [added 2013.03.26 waf]
 csa csa.berkeley.edu - -
 
 # [added 2013.03.13 tzhu]
 cisucb cis.berkeley.edu - /home
+cisucb cis.studentorg.berkeley.edu - /home [noindex]
 
 # [added 2013.03.10 waf]
 arias arias.berkeley.edu - -
+arias arias.studentorg.berkeley.edu - - [noindex]
 
 # [added 2013.03.05 tzhu]
 oai oa.berkeley.edu - -
+oai oa.studentorg.berkeley.edu - - [noindex]
 
 # [added 2013.02.25, waf]
-socsymp socsymp.berkeley.edu - -
+socsymp socsymp.berkeley.edu socsymp.studentorg.berkeley.edu -
 oratory oratory.berkeley.edu - -
+oratory oratory.studentorg.berkeley.edu - - [noindex]
 
 # [added 2013.02.19, waf]
 # albayan - - -
 ses ses.berkeley.edu - -
+ses ses.studentorg.berkeley.edu - - [noindex]
 
 # [added 2013.02.07, daradib]
 # Removed 2021-09-30 at request of Senior Class President
@@ -1505,18 +1707,22 @@ ses ses.berkeley.edu - -
 
 # [added 2013.01.28, daradib]
 zso zso.berkeley.edu - -
+zso zso.studentorg.berkeley.edu - - [noindex]
 
 # [added 2013.01.24, waf]
-caleq equestrian.berkeley.edu - -
+caleq equestrian.berkeley.edu equestrian.studentorg.berkeley.edu -
 
 # [added 2013.01.22, waf]
 specfic imaginarium.berkeley.edu - -
+specfic imaginarium.studentorg.berkeley.edu - - [noindex]
 
 # [added 2013.01.18, daradib]
 perspect perspective.berkeley.edu - -
+perspect perspective.studentorg.berkeley.edu - - [noindex]
 
 # [added 2013.01.04, waf]
 enactus enactus.berkeley.edu - -
+enactus enactus.studentorg.berkeley.edu - - [noindex]
 
 # [added 2012.11.25, daradib]
 # aavptp thinkplace - -
@@ -1526,14 +1732,19 @@ enactus enactus.berkeley.edu - -
 
 # [added 2012.10.05, tzhu]
 # phdcc phdconsulting - -
-pnc pawsandclaws.berkeley.edu - -
+pnc pawsandclaws.berkeley.edu pawsandclaws.studentorg.berkeley.edu -
 decollab dec.berkeley.edu - -
+decollab dec.studentorg.berkeley.edu - - [noindex]
 
 # [added 2012.09.25, tzhu]
 envision envision.berkeley.edu - -
+envision envision.studentorg.berkeley.edu - - [noindex]
 thrice tr.berkeley.edu - -
+thrice tr.studentorg.berkeley.edu - - [noindex]
 cycling cycling.berkeley.edu - -
+cycling cycling.studentorg.berkeley.edu - - [noindex]
 ace ace.berkeley.edu - -
+ace ace.studentorg.berkeley.edu - - [noindex]
 
 # [added 2012.09.11, daradib]
 # calasce calasce.org www.calasce.org -
@@ -1541,6 +1752,7 @@ ace ace.berkeley.edu - -
 #[added 2012.09.09, kedo]
 # changed rt#9252
 ssscr tmsca.berkeley.edu - -
+ssscr tmsca.studentorg.berkeley.edu - - [noindex]
 
 # [readded 2012.08.23, daradib]
 # linux - - -
@@ -1549,11 +1761,12 @@ ssscr tmsca.berkeley.edu - -
 # decal decal.ocf.berkeley.edu - -
 
 # [readded 2012.08.21, kedo]
-spirit calspirit.berkeley.edu - -
+spirit calspirit.berkeley.edu calspirit.studentorg.berkeley.edu -
 
 # [added 2012.08.21, kedo]
 aiaa aiaa.berkeley.edu - -
-dblab drubinbarneslab.berkeley.edu - -
+aiaa aiaa.studentorg.berkeley.edu - - [noindex]
+dblab drubinbarneslab.berkeley.edu drubinbarneslab.studentorg.berkeley.edu -
 
 # [added 2012.05.14, kedo]
 #wcsc! wcsc - -
@@ -1562,28 +1775,31 @@ dblab drubinbarneslab.berkeley.edu - -
 #jba jba - /wordpress
 
 # [added 2012.04.19, kedo]
-skiteam skiteam.berkeley.edu - -
+skiteam skiteam.berkeley.edu skiteam.studentorg.berkeley.edu -
 
 # [added 2012.04.17, daradib]
 calblog blog.admissions.berkeley.edu - /wordpress
 
 # [added 2012.04.17, kedo]
 seej seej.berkeley.edu - -
+seej seej.studentorg.berkeley.edu - - [noindex]
 
 # [added 2012.03.23, kedo]
 jsb jsb.berkeley.edu - -
+jsb jsb.studentorg.berkeley.edu - - [noindex]
 
 #[added 2012.03.17 sanjayk]
 #api api - -
 
 # [added 2012.03.12, kedo]
-paksa psa.berkeley.edu - -
+paksa psa.berkeley.edu psa.studentorg.berkeley.edu -
 
 # [added 2012.03.05, kedo]
-bcab bcab.berkeley.edu - -
+bcab bcab.berkeley.edu bcab.studentorg.berkeley.edu -
 
 # [added 2012.02.23, kedo]
 calcheer calcheerleading.berkeley.edu - -
+calcheer calcheerleading.studentorg.berkeley.edu - - [noindex]
 
 # [added 2012.02.08, kedo]
 # disabled 2019-02-13, switched to apphosting
@@ -1595,50 +1811,59 @@ bmt berkeley.mt www.berkeley.mt,bmt.berkeley.edu /new [301]
 
 # [added 2012.02.06, kedo]
 toxsa toxsa.berkeley.edu - -
+toxsa toxsa.studentorg.berkeley.edu - - [noindex]
 
 # [added 2012.02.02, kedo]
 # ucbcsl starleague - -
 
 # [added 2012.01.25, kedo]
-tiprison teachinprison.berkeley.edu - -
+tiprison teachinprison.berkeley.edu teachinprison.studentorg.berkeley.edu -
 
 # [added 2012.01.10, kedo]
-climbing climbing.berkeley.edu - -
+climbing climbing.berkeley.edu climbing.studentorg.berkeley.edu -
 
 # [added 2012.01.08, kedo]
 lipb lip.berkeley.edu - -
+lipb lip.studentorg.berkeley.edu - - [noindex]
 
 # [added 2012.01.06, kedo]
 # ccb consulting - -
 
 # [added 2011.12.21, kedo]
 sigma axs.berkeley.edu - -
+sigma axs.studentorg.berkeley.edu - - [noindex]
 
 # [added 2011.12.02, kedo]
 # medance middleeasterndance - /wordpress
 
 # [added 2011.11.10, kedo]
 sailing sailing.berkeley.edu - -
+sailing sailing.studentorg.berkeley.edu - - [noindex]
 
 # [added 2011.11.08, kedo]
 #aez - - -
 
 # [added 2011.11.02, kedo]
 eggster eggster.berkeley.edu - -
+eggster eggster.studentorg.berkeley.edu - - [noindex]
 
 # [added 2011.10.24, kedo]
 pvidea pvidealab.berkeley.edu - -
+pvidea pvidealab.studentorg.berkeley.edu - - [noindex]
 
 # [added 2011.10.17, kedo]
 # mengo meng - -
 elder b4ew.berkeley.edu - -
+elder b4ew.studentorg.berkeley.edu - - [noindex]
 
 # [added 2011.10.01, kedo]
 # sab synesthesia - -
 
 # [added 2011.09.28, kedo]
 harvest harvest.berkeley.edu - -
+harvest harvest.studentorg.berkeley.edu - - [noindex]
 calsteel steelbridge.berkeley.edu - -
+calsteel steelbridge.studentorg.berkeley.edu - - [noindex]
 
 # [added 2011.09.20, kedo]
 # updated 2020-02-11 cooperc, rt#8681
@@ -1648,7 +1873,9 @@ calsteel steelbridge.berkeley.edu - -
 
 # [added 2011.09.11, waf]
 phichi phichi.berkeley.edu - -
+phichi phichi.studentorg.berkeley.edu - - [noindex]
 unibball unibball.berkeley.edu - -
+unibball unibball.studentorg.berkeley.edu - - [noindex]
 
 # [added 2011.08.31, daradib]
 bluegold yearbook.berkeley.edu bluegold.berkeley.edu -
@@ -1657,8 +1884,9 @@ bluegold yearbook.berkeley.edu bluegold.berkeley.edu -
 # innod - - -
 
 # [added 2011.06.01, daradib]
-repercus repercussions.berkeley.edu - -
+repercus repercussions.berkeley.edu repercussions.studentorg.berkeley.edu -
 calsec calsec.berkeley.edu - -
+calsec calsec.studentorg.berkeley.edu - - [noindex]
 #calforum philforum - -
 
 # [added 2011.04.27, benortiz]
@@ -1667,40 +1895,51 @@ calsec calsec.berkeley.edu - -
 # baclu - - -
 
 # [added 2011.04.07, benortiz]
-basc basc.berkeley.edu - -
+basc basc.berkeley.edu basc.studentorg.berkeley.edu -
 # vproject visproject - -
 
 # [added 2011.04.01, daradib]
 clam clam.berkeley.edu - -
+clam clam.studentorg.berkeley.edu - - [noindex]
 #habitat poverty - /poverty
 habitat habitat.berkeley.edu - -
+habitat habitat.studentorg.berkeley.edu - - [noindex]
 
 # [added 2011.02.28, daradib] [in apphost as of 2016.05.27, kpengboy]
 #rcs rcsa - -
 
 # [added 2011.02.26, daradib] [updated sanjayk 2013.02.22]
-cssa cogscicon.berkeley.edu - /ccsc
+cssa cogscicon.berkeley.edu cogscicon.studentorg.berkeley.edu /ccsc
 cssa cssa.berkeley.edu - -
+cssa cssa.studentorg.berkeley.edu - - [noindex]
 corigami calorigami.berkeley.edu corigami.berkeley.edu -
+corigami calorigami.studentorg.berkeley.edu - - [noindex]
 appnet appnet.berkeley.edu - -
-kendo kendo.berkeley.edu - -
+appnet appnet.studentorg.berkeley.edu - - [noindex]
+kendo kendo.berkeley.edu kendo.studentorg.berkeley.edu -
 
 # [added 2011.02.08, daradib, hanwei]
-gmbberk gmb.berkeley.edu - /site
-medlife medlife.berkeley.edu - -
-fsbc fsbc.berkeley.edu - -
+gmbberk gmb.berkeley.edu gmb.studentorg.berkeley.edu /site
+medlife medlife.berkeley.edu medlife.studentorg.berkeley.edu -
+fsbc fsbc.berkeley.edu fsbc.studentorg.berkeley.edu -
 jmed jmed.berkeley.edu - -
+jmed jmed.studentorg.berkeley.edu - - [noindex]
 jewse jewse.berkeley.edu - -
+jewse jewse.studentorg.berkeley.edu - - [noindex]
 bcsa bcsa.berkeley.edu - -
+bcsa bcsa.studentorg.berkeley.edu - - [noindex]
 whitney whitneylab.berkeley.edu - -
+whitney whitneylab.studentorg.berkeley.edu - - [noindex]
 chiep xe.berkeley.edu - -
+chiep xe.studentorg.berkeley.edu - - [noindex]
 
 # [added 2011.01.23, daradib]
 contest contest.berkeley.edu - -
+contest contest.studentorg.berkeley.edu - - [noindex]
 
 # [added 2010.11.29, waf]
 # akd - - -
-eleven eleven.berkeley.edu - -
+eleven eleven.berkeley.edu eleven.studentorg.berkeley.edu -
 
 # [added 2010.11.01, waf]
 #aikido! - - -
@@ -1714,24 +1953,31 @@ ethical ethicalapparel.org www.ethicalapparel.org -
 
 # [added 2010.10.15, waf]
 fses fses.berkeley.edu - -
+fses fses.studentorg.berkeley.edu - - [noindex]
 ccycle citizencycle.berkeley.edu - -
+ccycle citizencycle.studentorg.berkeley.edu - - [noindex]
 
 # [added 2010.10.07, waf]
 #calconst! calconstruction - -
 aapihrg aapihrg.berkeley.edu - -
+aapihrg aapihrg.studentorg.berkeley.edu - - [noindex]
 
 # [added 2010.10.02, waf]
 # keucb kesherenoshi - -
-boaltglj genderlawjustice.berkeley.edu - -
+boaltglj genderlawjustice.berkeley.edu genderlawjustice.studentorg.berkeley.edu -
 
 # [added 2010.09.**, sanjayk]
 gkroeber kroeber.berkeley.edu - -
+gkroeber kroeber.studentorg.berkeley.edu - - [noindex]
 # [deleted 2017.11.27, baisang - they requested removal]
 #tikvah tikvahsfi - -
 # re-enabled 2019-02-14 cooperc (rt#8023)
 ucd ux.berkeley.edu - -
+ucd ux.studentorg.berkeley.edu - - [noindex]
 gcc gcc.berkeley.edu - -
+gcc gcc.studentorg.berkeley.edu - - [noindex]
 harvestm harvestmoon.berkeley.edu - -
+harvestm harvestmoon.studentorg.berkeley.edu - - [noindex]
 # rpowell - - -
 #phide! - - -
 #caldboat! caldragonboat - -
@@ -1756,9 +2002,11 @@ harvestm harvestmoon.berkeley.edu - -
 
 # [added 2010.03.13, alanw]
 puzzle puzzle.berkeley.edu - -
+puzzle puzzle.studentorg.berkeley.edu - - [noindex]
 
 # [added 2010.03.06, alanw]
 terrene terrene.berkeley.edu - -
+terrene terrene.studentorg.berkeley.edu - - [noindex]
 # [disabled 2018-02-26, jvperrin rt#7135]
 #calrun crc - -
 
@@ -1770,23 +2018,27 @@ terrene terrene.berkeley.edu - -
 
 # added 2020-06-09 jaw rt#9171
 calttc calttc.berkeley.edu - -
+calttc calttc.studentorg.berkeley.edu - - [noindex]
 
-dancewrx dwx.berkeley.edu - -
+dancewrx dwx.berkeley.edu dwx.studentorg.berkeley.edu -
 # busa - - -
-pmhs pmhs.berkeley.edu - -
+pmhs pmhs.berkeley.edu pmhs.studentorg.berkeley.edu -
 
 # [added 2009.12.30, mgasidlo]
 bliss bliss.berkeley.edu - -
+bliss bliss.studentorg.berkeley.edu - - [noindex]
 
 # [added 2009.12.05 alanw]
 reuse exchange.berkeley.edu - /exchange
-reuse reuse.berkeley.edu - -
+reuse exchange.studentorg.berkeley.edu - /exchange [noindex]
+reuse reuse.berkeley.edu reuse.studentorg.berkeley.edu -
 
 #bandalum calbandalumni - -
 #ibwis! wis - -
 
 # [added 2009.11.21 alanw]
 cgtones overtones.berkeley.edu - -
+cgtones overtones.studentorg.berkeley.edu - - [noindex]
 
 # [added 2009.11.8 alanw]
 #maganda - - -
@@ -1796,21 +2048,24 @@ cgtones overtones.berkeley.edu - -
 
 # [added 2009.10.27 alanw]
 kroeber kas.berkeley.edu - -
-psof coffinaward.berkeley.edu - -
+kroeber kas.studentorg.berkeley.edu - - [noindex]
+psof coffinaward.berkeley.edu coffinaward.studentorg.berkeley.edu -
 
 # [added 2009.10.19 alanw]
 # eswb esw - -
 scab scab.berkeley.edu - -
-imsu imsu.berkeley.edu - -
+scab scab.studentorg.berkeley.edu - - [noindex]
+imsu imsu.berkeley.edu imsu.studentorg.berkeley.edu -
 
 #[added 2009.10.19 sanjayk]
 rtb rt.berkeley.edu - -
+rtb rt.studentorg.berkeley.edu - - [noindex]
 
 # [added 2009.09.19 alanw]
 # ctennis clubtennis - -
 # smrt - - -
 #jsuucb! jsu - -
-ewb ewb.berkeley.edu - -
+ewb ewb.berkeley.edu ewb.studentorg.berkeley.edu -
 # isab - - -
 
 # [added 2009.09.25, mgasidlo]
@@ -1831,45 +2086,55 @@ ewb ewb.berkeley.edu - -
 
 # [added 2009.04.11, mgasidlo]
 # iabc - - -
-hsab hsab.berkeley.edu - -
+hsab hsab.berkeley.edu hsab.studentorg.berkeley.edu -
 #tblfg blive - -
 
 # [added 2009.03.05, jameson]
 tobaccno tobaccno.berkeley.edu - -
+tobaccno tobaccno.studentorg.berkeley.edu - - [noindex]
 # [removed 2013.07.14, tzhu]
 # npr npr - -
 # peace peacecorps - -
 
 # [added 2009.02.24, jameson]
 calhikes chaos.berkeley.edu - -
+calhikes chaos.studentorg.berkeley.edu - - [noindex]
 octet mensoctet.berkeley.edu - -
+octet mensoctet.studentorg.berkeley.edu - - [noindex]
 ucwc ucwc.berkeley.edu - -
+ucwc ucwc.studentorg.berkeley.edu - - [noindex]
 startup startup.berkeley.edu - -
+startup startup.studentorg.berkeley.edu - - [noindex]
 
 # [added 2009.02.10, mgasidlo]
-pubsoc publicsociology.berkeley.edu - -
-ucmc ucmc.berkeley.edu - -
+pubsoc publicsociology.berkeley.edu publicsociology.studentorg.berkeley.edu -
+ucmc ucmc.berkeley.edu ucmc.studentorg.berkeley.edu -
 
 # [added 2009.02.05, mgasidlo]
 pfifth perfectfifth.berkeley.edu - -
+pfifth perfectfifth.studentorg.berkeley.edu - - [noindex]
 caljazz caljazzchoir.berkeley.edu - -
+caljazz caljazzchoir.studentorg.berkeley.edu - - [noindex]
 
 # [added 2009.02.04, mgasidlo]
 # reinstated 4/19/23, rt#12827
 calband calband.berkeley.edu www.calband.berkeley.edu -
-choral ucchoral.berkeley.edu ucce.berkeley.edu -
+choral ucchoral.berkeley.edu ucce.berkeley.edu,ucchoral.studentorg.berkeley.edu -
 ucjazz ucjazz.berkeley.edu - -
+ucjazz ucjazz.studentorg.berkeley.edu - - [noindex]
 
 # [added 2009.01.30, mgasidlo]
-nwguys noteworthy.berkeley.edu - -
+nwguys noteworthy.berkeley.edu noteworthy.studentorg.berkeley.edu -
 moral moral.berkeley.edu - -
+moral moral.studentorg.berkeley.edu - - [noindex]
 # mind neurophilosophy - -
 
 # [added 2008.12.14, mgasidlo]
-ahsleep harveysleeplab.berkeley.edu - -
+ahsleep harveysleeplab.berkeley.edu harveysleeplab.studentorg.berkeley.edu -
 
 # [added 2008.11.20, mgasidlo]
 wcb wrestling.berkeley.edu - -
+wcb wrestling.studentorg.berkeley.edu - - [noindex]
 
 # [added 2008.11.15, mgasidlo]
 #hestia! hellenic - -
@@ -1881,36 +2146,45 @@ wcb wrestling.berkeley.edu - -
 
 # [added 2008.10.14, mgasidlo]
 facelab facelab.berkeley.edu - -
+facelab facelab.studentorg.berkeley.edu - - [noindex]
 culcog culcog.berkeley.edu - -
-zhoulab zhoulab.berkeley.edu - -
+culcog culcog.studentorg.berkeley.edu - - [noindex]
+zhoulab zhoulab.berkeley.edu zhoulab.studentorg.berkeley.edu -
 
 # [added 2008.10.01, mgasidlo]
 beacn beacn.berkeley.edu - -
+beacn beacn.studentorg.berkeley.edu - - [noindex]
 #ayj ayj - -
 #gmsa! gmsa - -
 jethics journalofethics.berkeley.edu - -
+jethics journalofethics.studentorg.berkeley.edu - - [noindex]
 
 # [added 2008.09.21, mgasidlo]
 #cac! relayforlife - -
 
 # [added 2008.09.08, aoaks]
 innoe innoe.berkeley.edu - -
+innoe innoe.studentorg.berkeley.edu - - [noindex]
 # mstacks mainstacks - -
 caps caps.berkeley.edu - -
+caps caps.studentorg.berkeley.edu - - [noindex]
 #iie - - -
 
 # [added 2008.08.29, aoaks]
 koinonia koinonia.berkeley.edu - -
+koinonia koinonia.studentorg.berkeley.edu - - [noindex]
 kairos kairos.berkeley.edu - -
+kairos kairos.studentorg.berkeley.edu - - [noindex]
 # uma - - -
 # modified 2018-11-28 dkessler
 # modified 2019-02-01 cooperc (oldsite -> oldstatic)
 # modified 2023-05-26 kian rt#12984 (oldstatic -> root)
-airport airportdesign.berkeley.edu - -
+airport airportdesign.berkeley.edu airportdesign.studentorg.berkeley.edu -
 # aviation - - -
 
 # [added 2008.08.26, aoaks]
 poly poly.berkeley.edu - -
+poly poly.studentorg.berkeley.edu - - [noindex]
 #acts! a2f - -
 
 # [added 2008.08.19, aoaks]
@@ -1918,6 +2192,7 @@ poly poly.berkeley.edu - -
 
 # [added 2008.08.13, aoaks]
 iai interfaith.berkeley.edu - -
+iai interfaith.studentorg.berkeley.edu - - [noindex]
 
 # [added 2008.08.07, aoaks]
 #beam - - -
@@ -1942,37 +2217,45 @@ iai interfaith.berkeley.edu - -
 
 # [added 2008.06.20, aoaks]
 cedrugby cedrugby.berkeley.edu - -
+cedrugby cedrugby.studentorg.berkeley.edu - - [noindex]
 
 # [added 2008.05.22, aoaks]
 goldkey goldenkey.berkeley.edu - -
+goldkey goldenkey.studentorg.berkeley.edu - - [noindex]
 nutmeg nutmeg.berkeley.edu - -
+nutmeg nutmeg.studentorg.berkeley.edu - - [noindex]
 ifdance israelidance.berkeley.edu - -
+ifdance israelidance.studentorg.berkeley.edu - - [noindex]
 
 # [added 2008.05.03, aoaks]
 # ewh - - -
 
 # [added 2008.05.02, aoaks]
 millslab millslab.berkeley.edu - -
+millslab millslab.studentorg.berkeley.edu - - [noindex]
 
 # [added 2008.04.09, aoaks]
 afghans afghans.berkeley.edu - -
+afghans afghans.studentorg.berkeley.edu - - [noindex]
 gapple goldenapple.berkeley.edu - -
+gapple goldenapple.studentorg.berkeley.edu - - [noindex]
 
 # [added 2008.03.20, sluo]
 # thecalif californians - -
 #bcec - - -
 
 # [added 2008.02.07, milki]
-tmc tmc.berkeley.edu - -
+tmc tmc.berkeley.edu tmc.studentorg.berkeley.edu -
 # replaced by bmj, 2020-02-03, cooperc in-person
 # if you're reading this you should probably comment the following line
-issues issues.berkeley.edu - -
+issues issues.berkeley.edu issues.studentorg.berkeley.edu -
 
 # [added 2008.01.31, milki]
 # [removed 2008.02.07, milki]
 # [reenabled 2008.02.10, milki]
 # [reenabled 2020.12.25, fydai, rt#9792]
 aba aba.berkeley.edu - -
+aba aba.studentorg.berkeley.edu - - [noindex]
 
 # [added 2008.01.25, milki]
 #tgif tgif - -
@@ -1991,9 +2274,11 @@ aba aba.berkeley.edu - -
 
 # [added 2007.10.29, thomson]
 tsab tsab.berkeley.edu - -
+tsab tsab.studentorg.berkeley.edu - - [noindex]
 
 # [added 2007.10.12, sluo]
 cdt ftd.berkeley.edu - -
+cdt ftd.studentorg.berkeley.edu - - [noindex]
 #vday! - - -
 
 # [added 2007.10.04, sluo]
@@ -2008,28 +2293,33 @@ cdt ftd.berkeley.edu - -
 
 # [added 2007.09.11, sluo]
 # aias - - -
-mcbusa mcbusa.berkeley.edu - -
+mcbusa mcbusa.berkeley.edu mcbusa.studentorg.berkeley.edu -
 #berknow! now - -
 
 # [added 2007.08.31, aoaks]
 #ucbmun mun - -
 ccm ccm.berkeley.edu - -
+ccm ccm.studentorg.berkeley.edu - - [noindex]
 #dstkappa! dstkappa - -
 swe swe.berkeley.edu - -
+swe swe.studentorg.berkeley.edu - - [noindex]
 
 # [added 2007.08.23, aoaks]
 #reach! reach - -
 
 # [added 2007.07.10, aoaks]
 battery battery.berkeley.edu - -
+battery battery.studentorg.berkeley.edu - - [noindex]
 # gammaphi gammaphibeta - -
 
 # [added 2007.05.18, aoaks]
 # [revised 2018-07-14 jvperrin rt#7377]
 engle e98.berkeley.edu - -
+engle e98.studentorg.berkeley.edu - - [noindex]
 
 # [added 2007.05.08, aoaks]
 caltaiko taiko.berkeley.edu - -
+caltaiko taiko.studentorg.berkeley.edu - - [noindex]
 # unlimit up - -
 #bmes! bmes - -
 
@@ -2044,9 +2334,10 @@ caltaiko taiko.berkeley.edu - -
 # sfhbc sfhbc - -
 
 # [added 2007.03.01, aoaks]
-spie photobears.berkeley.edu - -
+spie photobears.berkeley.edu photobears.studentorg.berkeley.edu -
 # magnolia magnoliaproject - -
 pass pass.berkeley.edu - -
+pass pass.studentorg.berkeley.edu - - [noindex]
 #binnov! eflyer - /eflyer
 
 # [added 2007.2.20, sluo]
@@ -2058,7 +2349,7 @@ pass pass.berkeley.edu - -
 # unicef bearsforunicef - -
 
 # [added 2007.2.07, aoaks]
-caleague actuary.berkeley.edu - -
+caleague actuary.berkeley.edu actuary.studentorg.berkeley.edu -
 
 # [added 2007.2.07, aoaks]
 # lsab lebanese - -
@@ -2067,23 +2358,27 @@ caleague actuary.berkeley.edu - -
 # [added 2007.1.31, thomson]
 #caldsu! dsu - -
 jjoyce jamesjoyce.berkeley.edu - -
+jjoyce jamesjoyce.studentorg.berkeley.edu - - [noindex]
 # [added 2007.1.21, thomson]
-asme asme.berkeley.edu - -
+asme asme.berkeley.edu asme.studentorg.berkeley.edu -
 # [added 2007.1.16, thomson!]
 # minamuc minamuc - -
 # [added 2006.12.05, thomson!]
 # access calaccess - -
 pup pup.berkeley.edu - -
+pup pup.studentorg.berkeley.edu - - [noindex]
 # [edited 2014.9.12, nickimp]
 smashab smash.berkeley.edu - -
+smashab smash.studentorg.berkeley.edu - - [noindex]
 
 # [added 2006.11.29, thomson!]
 # roots roots - -
 # newman newman - -
 uaem uaem.berkeley.edu - -
+uaem uaem.studentorg.berkeley.edu - - [noindex]
 
 # [added 2006.11.18, yury]
-slc studentlegalclinic.berkeley.edu - -
+slc studentlegalclinic.berkeley.edu studentlegalclinic.studentorg.berkeley.edu -
 
 # [added 2006.11.3, sle]
 # greens greens - -
@@ -2095,18 +2390,19 @@ slc studentlegalclinic.berkeley.edu - -
 
 # [added 2006.9.16, sle]
 aol artofliving.berkeley.edu - -
+aol artofliving.studentorg.berkeley.edu - - [noindex]
 # tennis tennis - -
-archery archery.berkeley.edu - -
+archery archery.berkeley.edu archery.studentorg.berkeley.edu -
 # wocff wocff - -
 
 # [added 2006.8.23, jerjou]
 #thebp! bp - -
-break breakthrough.berkeley.edu - -
+break breakthrough.berkeley.edu breakthrough.studentorg.berkeley.edu -
 # juris broken, added ! [2007.09.11, sluo]
 #blsa! juris - /juris
 
 # [added 2006.7.14, sluo]
-clios clios.berkeley.edu - -
+clios clios.berkeley.edu clios.studentorg.berkeley.edu -
 
 # [added 2006.04.24, jerjou]
 # eco enviro - -
@@ -2119,11 +2415,12 @@ clios clios.berkeley.edu - -
 # [added 2006.3.14, sluo]
 # eyes themiddleground - -
 # burs - - -
-conlangs conlangs.berkeley.edu - -
+conlangs conlangs.berkeley.edu conlangs.studentorg.berkeley.edu -
 #dancemar! dancemarathon - -
 
 # [added 2006.3.3, jerjou]
 bfsc figureskating.berkeley.edu - -
+bfsc figureskating.studentorg.berkeley.edu - - [noindex]
 
 # [added 2006.2.28, sluo]
 # sacrun - - -
@@ -2148,10 +2445,13 @@ bfsc figureskating.berkeley.edu - -
 
 # [added 2006.1.26, dima]
 caldance caldanceteam.berkeley.edu - -
+caldance caldanceteam.studentorg.berkeley.edu - - [noindex]
 
 # [added 2005.12.19, dima]
 sigmanu sigmanu.berkeley.edu - -
+sigmanu sigmanu.studentorg.berkeley.edu - - [noindex]
 christ christiansoncampus.berkeley.edu - -
+christ christiansoncampus.studentorg.berkeley.edu - - [noindex]
 
 # [added 2005.12.11, jerjou]
 # waiting on whether password-protected is okay
@@ -2159,6 +2459,7 @@ christ christiansoncampus.berkeley.edu - -
 # [2005.12.15, novakyu]
 #baseball! clubbaseball - -
 sgb sgb.berkeley.edu - -
+sgb sgb.studentorg.berkeley.edu - - [noindex]
 
 # [added 2005.11.17, jerjou]
 # truel truelement - -
@@ -2177,10 +2478,10 @@ sgb sgb.berkeley.edu - -
 #aphia! - - -
 
 # [added 2005.09.29, jerjou]
-msea msea.berkeley.edu - -
+msea msea.berkeley.edu msea.studentorg.berkeley.edu -
 # idea - - -
 #umca! - - -
-hes hes.berkeley.edu - -
+hes hes.berkeley.edu hes.studentorg.berkeley.edu -
 #citc - - -
 
 # previously had hapa.b.e
@@ -2192,12 +2493,14 @@ hes hes.berkeley.edu - -
 # [added 2005.08.30, jerjou]
 # restored rt#9002
 suitcase suitcase.berkeley.edu - -
+suitcase suitcase.studentorg.berkeley.edu - - [noindex]
 
 # [added 2005.08.07, jerjou]
 pasae pasae.berkeley.edu - -
+pasae pasae.studentorg.berkeley.edu - - [noindex]
 
 # [added 2005.07.17, jerjou]
-sca sca.berkeley.edu - -
+sca sca.berkeley.edu sca.studentorg.berkeley.edu -
 # tmclub tm - -
 
 # [added 2005.07.03, jerjou]
@@ -2214,21 +2517,24 @@ sca sca.berkeley.edu - -
 # trihelix triplehelix - -
 # conflict - - -
 # [added 2005.04.30, jerjou]
-sspc sspc.berkeley.edu - -
+sspc sspc.berkeley.edu sspc.studentorg.berkeley.edu -
 hboiled hardboiled.berkeley.edu - -
+hboiled hardboiled.studentorg.berkeley.edu - - [noindex]
 # [added 2005.04.19, jerjou]
 # navs navigators - -
 # clsj - - -
-gasp gasp.berkeley.edu - -
+gasp gasp.berkeley.edu gasp.studentorg.berkeley.edu -
 # [added 2005.03.20, jerjou]
 #iaeste! - - -
-blsa blsa.berkeley.edu - -
+blsa blsa.berkeley.edu blsa.studentorg.berkeley.edu -
 # [added 2005.03.06, geo]
 calarabs asu.berkeley.edu - -
+calarabs asu.studentorg.berkeley.edu - - [noindex]
 # [added 2005.03.02, geo]
-advocate advocate.berkeley.edu - -
+advocate advocate.berkeley.edu advocate.studentorg.berkeley.edu -
 # [added 2005.02.26, geo]
 badmintn badminton.berkeley.edu - -
+badmintn badminton.studentorg.berkeley.edu - - [noindex]
 # beta - - -
 # [added 2005.02.25, geo]
 # uaa - - -
@@ -2260,13 +2566,16 @@ quiparle quiparle.berkeley.edu - -
 # syw - - -
 # [added 2004.11.25, geo]
 nsu nsu.berkeley.edu - -
+nsu nsu.studentorg.berkeley.edu - - [noindex]
 # [added 2004.11.16, geo]
 # tieye - - -
 # [added 2004.11.09, geo]
 # politica - - -
 slugs slugs.berkeley.edu - -
+slugs slugs.studentorg.berkeley.edu - - [noindex]
 # [added 2004.11.05, jkit]
 fast fashion.berkeley.edu - -
+fast fashion.studentorg.berkeley.edu - - [noindex]
 # [added 2004.11.01, geo]
 # bpha - - -
 # [added 2004.10.08, jkit]
@@ -2274,6 +2583,7 @@ fast fashion.berkeley.edu - -
 # caltt - - -
 # ucbaaf aaf - -
 rascl rascl.berkeley.edu - -
+rascl rascl.studentorg.berkeley.edu - - [noindex]
 
 # [moved from hosts.conf Oct. 1, 2004 - tee]
 #wndrwrks! wonderworks - -
@@ -2287,6 +2597,7 @@ rascl rascl.berkeley.edu - -
 # bridges! - - -
 # sikhi! - - -
 redcross redcross.berkeley.edu - -
+redcross redcross.studentorg.berkeley.edu - - [noindex]
 #bioehs - - -
 # bcr gop - -
 # bmac - - -
@@ -2300,6 +2611,7 @@ redcross redcross.berkeley.edu - -
 
 # [added Apr. 27, 2004 - jkit]
 vagabond vagabond.berkeley.edu - -
+vagabond vagabond.studentorg.berkeley.edu - - [noindex]
 # biosp! bsp - -
 # msdosx - - - [disabled 2018-05-05 abizer, site is unused]
 #gamers! gamescrafters - -
@@ -2321,6 +2633,7 @@ aacf aacf.berkeley.edu - -
 # [added Mar. 1, 2004 -jkit]
 #bioediv! - - -
 bst bst.berkeley.edu - -
+bst bst.studentorg.berkeley.edu - - [noindex]
 # nano! nanoclub - -
 
 # [added Feb. 21, 2004 -jkit]
@@ -2333,10 +2646,11 @@ bst bst.berkeley.edu - -
 # soid! - - -
 #crusade caljourney - -
 dpe dpe.berkeley.edu - -
+dpe dpe.studentorg.berkeley.edu - - [noindex]
 # [added 12/09/2003 -jones]
 #asucrla! - - -
 # ucbugg - - -
-bpreview bpr.berkeley.edu - -
+bpreview bpr.berkeley.edu bpr.studentorg.berkeley.edu -
 # [added 12/1/2003 - jones]
 # shkca - - -
 # [added 11/21/2003 -jones]
@@ -2352,9 +2666,11 @@ bpreview bpr.berkeley.edu - -
 # [added 10/14/2003 -jones]
 # fiji! - - -
 musa musa.berkeley.edu - -
+musa musa.studentorg.berkeley.edu - - [noindex]
 # nofrills - - -
 #hawaii! calhawaii - -
 binnov innovation.berkeley.edu - -
+binnov innovation.studentorg.berkeley.edu - - [noindex]
 # brrc - - -
 # onecbm - - -
 #live has been removed for hacking the ASUC
@@ -2367,6 +2683,7 @@ binnov innovation.berkeley.edu - -
 #asuc www.asuc.org asuc.org -
 #decal www.decal.org decal.org -
 ucrc ucrc.berkeley.edu - -
+ucrc ucrc.studentorg.berkeley.edu - - [noindex]
 # fleet! - - -
 # martian! mars2012 - -
 #csba has been removed for hacking the ASUC website
@@ -2377,29 +2694,31 @@ ucrc ucrc.berkeley.edu - -
 # sigep - - -
 # apath - - -
 # election - - -
-hmap hmap.berkeley.edu - -
+hmap hmap.berkeley.edu hmap.studentorg.berkeley.edu -
 # inspire! - - -
 # It's broken, and it's a user's site. [4/12/06, jerjou]
 #davidf gobears.ocf.berkeley.edu gobears,gobears.* -
 # rockon! - - -
 
 dcadence decadence.berkeley.edu - -
+dcadence decadence.studentorg.berkeley.edu - - [noindex]
 #ahimsa! - - -
 #rcsa - - -
 #bahai! - - -
 #modified ejc to point to esc - kedo 2011/09/20
 ejc esc.berkeley.edu ejc.berkeley.edu -
+ejc esc.studentorg.berkeley.edu - - [noindex]
 # mortarbd! mortarboard - -
 # ases! - - -
-asa asa.berkeley.edu - -
+asa asa.berkeley.edu asa.studentorg.berkeley.edu -
 # sigmak - - -
 #ega! - - -
 # beast! bioengineers - -
 # rt#13493
 karate karate.berkeley.edu - -
-rblsa russian.berkeley.edu - -
+rblsa russian.berkeley.edu russian.studentorg.berkeley.edu -
 # kgsa! - - -
-bforum forum.berkeley.edu www.forum.berkeley.edu -
+bforum forum.berkeley.edu www.forum.berkeley.edu,forum.studentorg.berkeley.edu -
 # tomodach tomodachi - -
 # berj! - - -
 #cssa - - -
@@ -2408,21 +2727,26 @@ bforum forum.berkeley.edu www.forum.berkeley.edu -
 #msa - - -
 # basa! - - -
 # estp - - -
-fencing fencing.berkeley.edu - -
+fencing fencing.berkeley.edu fencing.studentorg.berkeley.edu -
 # gcbs - - -
 # calpsp psp - -
-cjc cjc.berkeley.edu - -
+cjc cjc.berkeley.edu cjc.studentorg.berkeley.edu -
 # isaa - - -
 # ucbdean! studentsfordean - -
 #[added by eleen 2004.07.01]
 # sensors! - - -
 bconsult bc.berkeley.edu - -
+bconsult bc.studentorg.berkeley.edu - - [noindex]
 #[added by dwc 10/04 (requested 9/03)]
 #asuc! mycal - /mycal
 #greekrc grc - -
 bisa bisa.berkeley.edu - -
+bisa bisa.studentorg.berkeley.edu - - [noindex]
 # bcm bcm - -
 sanl walkerlab.berkeley.edu - -
+sanl walkerlab.studentorg.berkeley.edu - - [noindex]
 hebrew hebrew.berkeley.edu - -
+hebrew hebrew.studentorg.berkeley.edu - - [noindex]
 ubjc ubjc.berkeley.edu - -
+ubjc ubjc.studentorg.berkeley.edu - - [noindex]
 minos minospark.com - -


### PR DESCRIPTION
* WordPress vhosts were added as redirects
* non-WordPress vhosts were added pointing to the same document root without redirects
