### PR TITLE
remove old non-studentorg mail vhosts

### DIFF
--- a/configs/vhost-mail.conf
+++ b/configs/vhost-mail.conf
@@ -15,7 +15,6 @@ usiorg usi.studentorg.berkeley.edu
 spaceformgroup spaceform.studentorg.berkeley.edu
 
 # rt#13141
-asrb asrb.berkeley.edu
 asrb asrb.studentorg.berkeley.edu
 
 # rt#13376
@@ -52,1250 +51,898 @@ zial bis.studentorg.berkeley.edu
 thebp berkeleyproject.org
 
 # rt#12875
-gwenn seismic.berkeley.edu
 gwenn seismic.studentorg.berkeley.edu
 
 # rt#12837
 substrate substratelabs.dev
 
 # rt#12764
-slugs slugs.berkeley.edu
 slugs slugs.studentorg.berkeley.edu
 
 # rt#11915
-powerbayarea powerbayarea.berkeley.edu
 powerbayarea powerbayarea.studentorg.berkeley.edu
 
 # rt#11851
-bsgsa bsgsa.berkeley.edu
 bsgsa bsgsa.studentorg.berkeley.edu
 
 # rt#11825
-sis southindiansociety.berkeley.edu
 sis southindiansociety.studentorg.berkeley.edu
 
 # rt#11663
-hsc hsc.berkeley.edu
 hsc hsc.studentorg.berkeley.edu
 
 # rt#11600
-bessa bessa.berkeley.edu
 bessa bessa.studentorg.berkeley.edu
 
 # rt#11572
-sensibility sensibility.berkeley.edu
 sensibility sensibility.studentorg.berkeley.edu
 
 # rt#11537
-calcodeology codeology.berkeley.edu
 calcodeology codeology.studentorg.berkeley.edu
 
 # rt#11546
-beam beam.berkeley.edu
 beam beam.studentorg.berkeley.edu
 
 # rt#11530
-bioscienceallian biox.berkeley.edu
 bioscienceallian biox.studentorg.berkeley.edu
 
 # rt#11482
-enviro enviroteam.berkeley.edu
 enviro enviroteam.studentorg.berkeley.edu
 
 # rt#11440
-cqg cqg.berkeley.edu
 cqg cqg.studentorg.berkeley.edu
 
 # rt#11381
-pab pab.berkeley.edu
 pab pab.studentorg.berkeley.edu
 
 # rt#11295
-pmh pawsformentalhealth.berkeley.edu
 pmh pawsformentalhealth.studentorg.berkeley.edu
 
 # rt#11302
-fedchallenge fedchallenge.berkeley.edu
 fedchallenge fedchallenge.studentorg.berkeley.edu
 
 # rt#11247
-globalinvestors globalinvestors.berkeley.edu
 globalinvestors globalinvestors.studentorg.berkeley.edu
 
 # rt#11026
-skateboarding skateboarding.berkeley.edu
 skateboarding skateboarding.studentorg.berkeley.edu
 
 # rt#11220
-fourdcapital 4dcapital.berkeley.edu
 fourdcapital 4dcapital.studentorg.berkeley.edu
 
 # rt#11215
-eggster eggster.berkeley.edu
 eggster eggster.studentorg.berkeley.edu
 
 # rt#11058
-blit blit.berkeley.edu
 blit blit.studentorg.berkeley.edu
 
 # rt#11035
-calttc calttc.berkeley.edu
 calttc calttc.studentorg.berkeley.edu
 
 # rt#11005
-cluj cluj.berkeley.edu
 cluj cluj.studentorg.berkeley.edu
 
 # rt#10967
-capclub capclub.berkeley.edu
 capclub capclub.studentorg.berkeley.edu
 
 # rt#10942
-bmf mfb.berkeley.edu
 bmf mfb.studentorg.berkeley.edu
 
 # rt#10898
-inm inm.berkeley.edu
 inm inm.studentorg.berkeley.edu
 
 # rt#10889
-calproductspace product.berkeley.edu
 calproductspace product.studentorg.berkeley.edu
 
 # rt#10868
-eecsdiscord eecsdiscord.berkeley.edu
 eecsdiscord eecsdiscord.studentorg.berkeley.edu
 
 # rt#10432
-information asl.berkeley.edu
 information asl.studentorg.berkeley.edu
 
 # rt#10572
-afghans calasa.berkeley.edu
 afghans calasa.studentorg.berkeley.edu
 
 # rt#10606
-figc figc.berkeley.edu
 figc figc.studentorg.berkeley.edu
 
 # rt#10619
-legends legends.berkeley.edu
 legends legends.studentorg.berkeley.edu
 
 # rt#10605
-fightinggames fightinggames.berkeley.edu
 fightinggames fightinggames.studentorg.berkeley.edu
 
 # rt#10380
-btc btc.berkeley.edu
 btc btc.studentorg.berkeley.edu
 
 # rt#10587
-ifb ifb.berkeley.edu
 ifb ifb.studentorg.berkeley.edu
 
 # rt#10544
-grepml grepml.berkeley.edu
 grepml grepml.studentorg.berkeley.edu
 
 # staff hours (migrating to calico.cs.b.e)
 calico calico.cs.berkeley.edu
 
 # rt#10523
-calico calico.berkeley.edu
 calico calico.studentorg.berkeley.edu
 
 # rt#10387
-bikebuilders bikebuilders.berkeley.edu
 bikebuilders bikebuilders.studentorg.berkeley.edu
 
 # rt#10334
-qarc queer.berkeley.edu
 qarc queer.studentorg.berkeley.edu
-qarc qarc.berkeley.edu
 qarc qarc.studentorg.berkeley.edu
 
 # rt#10371
-transpo transpo.berkeley.edu
 transpo transpo.studentorg.berkeley.edu
 
 # rt#10286
-ujpb ujpb.berkeley.edu
 ujpb ujpb.studentorg.berkeley.edu
 
 # rt#10084
-mixed mixed.berkeley.edu
 mixed mixed.studentorg.berkeley.edu
 
 # rt#10127
-aarj aarj.berkeley.edu
 aarj aarj.studentorg.berkeley.edu
 
 # rt#10004
-powerandenergy powerandenergy.berkeley.edu
 powerandenergy powerandenergy.studentorg.berkeley.edu
 
 # staff hours + rt#10020
-mpasforempower mpa4je.berkeley.edu
 mpasforempower mpa4je.studentorg.berkeley.edu
 
 # rt#10083
-horrorhouse horrorhouse.berkeley.edu
 horrorhouse horrorhouse.studentorg.berkeley.edu
 
 # rt#10047
-traders traders.berkeley.edu
 traders traders.studentorg.berkeley.edu
 
 # rt#10011
-paneltothepeople p2tp.berkeley.edu
 paneltothepeople p2tp.studentorg.berkeley.edu
 
 # staff hours
-disabilitylab disability.berkeley.edu
 disabilitylab disability.studentorg.berkeley.edu
 
 # rt#9924
-citizensclimate citizensclimate.berkeley.edu
 citizensclimate citizensclimate.studentorg.berkeley.edu
 
 # rt#9874
-policy policy.berkeley.edu
 policy policy.studentorg.berkeley.edu
 
 # rt#9835
-philforum philforum.berkeley.edu
 philforum philforum.studentorg.berkeley.edu
 
 # rt#9831
-physics sps.berkeley.edu
 physics sps.studentorg.berkeley.edu
 
 # in-person
-thaisa thaisa.berkeley.edu
 thaisa thaisa.studentorg.berkeley.edu
 
 # rt#9789
-ioc ioc.berkeley.edu
 ioc ioc.studentorg.berkeley.edu
 
 # rt#9761
-surg surg.berkeley.edu
 surg surg.studentorg.berkeley.edu
 
 # rt#9730
-megsco megsco.berkeley.edu
 megsco megsco.studentorg.berkeley.edu
 
 # rt#9753
-kmoverse kmo.berkeley.edu
 kmoverse kmo.studentorg.berkeley.edu
 
 # rt#9644
-exsurgo exsurgo.berkeley.edu
 exsurgo exsurgo.studentorg.berkeley.edu
 
 # rt#9677
-statusa susa.berkeley.edu
 statusa susa.studentorg.berkeley.edu
 
 # rt#9671
-amanecer amanecer.berkeley.edu
 amanecer amanecer.studentorg.berkeley.edu
 
 # rt#9605
-sky skyhappiness.berkeley.edu
 sky skyhappiness.studentorg.berkeley.edu
 
 # rt#9513
-prytanean prytanean.berkeley.edu
 prytanean prytanean.studentorg.berkeley.edu
 
 # rt#9622
-menaspla menaspla.berkeley.edu
 menaspla menaspla.studentorg.berkeley.edu
 
 # rt#11746
 # rt#9598
-combatrobotics combatrobotics.berkeley.edu
 combatrobotics combatrobotics.studentorg.berkeley.edu
 
 # rt#9568
-mlo mlo.berkeley.edu
 mlo mlo.studentorg.berkeley.edu
 
 # rt#9568
-bmt bmt.berkeley.edu
 bmt bmt.studentorg.berkeley.edu
 bmt berkeley.mt
 
 # rt#9545
-nedc nedc.berkeley.edu
 nedc nedc.studentorg.berkeley.edu
 
 # rt#9537
-swagg swagg.berkeley.edu
 swagg swagg.studentorg.berkeley.edu
 
 # rt#9535
-rics rics.berkeley.edu
 rics rics.studentorg.berkeley.edu
 
 # rt#9396
-pie pioneers.berkeley.edu
 pie pioneers.studentorg.berkeley.edu
 
 # rt#9516
-consulting cschool.berkeley.edu
 consulting cschool.studentorg.berkeley.edu
 
 # rt#9518
-ngn ngn.berkeley.edu
 ngn ngn.studentorg.berkeley.edu
 
 # rt#9508
-cahpsa cahpsa.berkeley.edu
 cahpsa cahpsa.studentorg.berkeley.edu
 
 # rt#9506
-sspc sspc.berkeley.edu
 sspc sspc.studentorg.berkeley.edu
 
 # rt#9494
-cloudcomputing cloudcomputing.berkeley.edu
 cloudcomputing cloudcomputing.studentorg.berkeley.edu
 
 # rt#9486
-beeps beeps.berkeley.edu
 beeps beeps.studentorg.berkeley.edu
 
 # rt#9475
-brownissues brownissues.berkeley.edu
 brownissues brownissues.studentorg.berkeley.edu
 
 # rt#9478
-asae asae.berkeley.edu
 asae asae.studentorg.berkeley.edu
 
 # rt#9474
-aiche aiche.berkeley.edu
 aiche aiche.studentorg.berkeley.edu
 
 # rt#9465
-snahp snahp.berkeley.edu
 snahp snahp.studentorg.berkeley.edu
 
 # rt#9437
-deltaconsulting deltaconsulting.berkeley.edu
 deltaconsulting deltaconsulting.studentorg.berkeley.edu
 
 # rt#9439
-otd otd.berkeley.edu
 otd otd.studentorg.berkeley.edu
 
 # rt#9438
-uweb uweb.berkeley.edu
 uweb uweb.studentorg.berkeley.edu
 
 # rt#9423
-newvoters newvoters.berkeley.edu
 newvoters newvoters.studentorg.berkeley.edu
 
 # rt#9411
-ostem ostem.berkeley.edu
 ostem ostem.studentorg.berkeley.edu
 
 # rt#9391
-abetterway abetterway.berkeley.edu
 abetterway abetterway.studentorg.berkeley.edu
 
 # rt#9377
-healsca healsca.berkeley.edu
 healsca healsca.studentorg.berkeley.edu
 
 # rt#9353
-itot itot.berkeley.edu
 itot itot.studentorg.berkeley.edu
 
 # rt#9305
-space stars.berkeley.edu
 space stars.studentorg.berkeley.edu
 
 # rt#9341
-anova anova.berkeley.edu
 anova anova.studentorg.berkeley.edu
 
 # rt#9314
-isaa isaa.berkeley.edu
 isaa isaa.studentorg.berkeley.edu
 
 # rt#9334
-calasla asla.berkeley.edu
 calasla asla.studentorg.berkeley.edu
 
 # rt#9002
-suitcase suitcase.berkeley.edu
 suitcase suitcase.studentorg.berkeley.edu
 
 # rt#9311
-predents pds.berkeley.edu
 predents pds.studentorg.berkeley.edu
 
 # rt#9300
-datagood datagood.berkeley.edu
 datagood datagood.studentorg.berkeley.edu
 
 # rt#9286
-hes hes.berkeley.edu
 hes hes.studentorg.berkeley.edu
 
 # rt#9282
-connectcal connected.berkeley.edu
 connectcal connected.studentorg.berkeley.edu
 
 # rt#9279
-wdd wdd.berkeley.edu
 wdd wdd.studentorg.berkeley.edu
 
 # rt#9045
-seismic seismic.berkeley.edu
 seismic seismic.studentorg.berkeley.edu
 
 # rt#9275
-bsj bsj.berkeley.edu
 bsj bsj.studentorg.berkeley.edu
 
 # rt#9269
-igem igem.berkeley.edu
 igem igem.studentorg.berkeley.edu
 
 # rt#9255
-ume ume.berkeley.edu
 ume ume.studentorg.berkeley.edu
 
 # rt#9222
-calcanoe concretecanoe.berkeley.edu
 calcanoe concretecanoe.studentorg.berkeley.edu
 
 # rt#9219
-bigdata bd.berkeley.edu
 bigdata bd.studentorg.berkeley.edu
 
 # rt#9213
-espmgdc espmgdc.berkeley.edu
 espmgdc espmgdc.studentorg.berkeley.edu
 
 # rt#9207
-csks cs-kickstart.berkeley.edu
 csks cs-kickstart.studentorg.berkeley.edu
 
 # added 2020-06-22 jaw rt#9202
-fsae fsae.berkeley.edu
 fsae fsae.studentorg.berkeley.edu
 
 # added 2020-06-16 jaw rt#9125
-ysa ysa.berkeley.edu
 ysa ysa.studentorg.berkeley.edu
 
 # added 2020-06-16 jaw rt#9172
-gwe gwe.berkeley.edu
 gwe gwe.studentorg.berkeley.edu
 
 # added 2020-06-15 jaw rt#9193
-chiep xe.berkeley.edu
 chiep xe.studentorg.berkeley.edu
 
 # added 2020-06-12 minos in-person
 uav theprojectboom.org
 
 # added 2020-06-12 jaw rt#9175
-geowall geowall.berkeley.edu
 geowall geowall.studentorg.berkeley.edu
 
 # added 2020-06-06 jaw rt#9147
-launchpad launchpad.berkeley.edu
 launchpad launchpad.studentorg.berkeley.edu
 
 # added 2020-06-06 jaw rt#9145
-bearshare bearshare.berkeley.edu
 bearshare bearshare.studentorg.berkeley.edu
 
 # added 2020-06-02 jaw rt#9133
-slrpev slrpev.berkeley.edu
 slrpev slrpev.studentorg.berkeley.edu
 
 # added 2020-05-31 jaw rt#9124
-girlup girlup.berkeley.edu
 girlup girlup.studentorg.berkeley.edu
 
 # added 2020-05-27 jaw rt#9082
-fblapbl pbl.berkeley.edu
 fblapbl pbl.studentorg.berkeley.edu
 
 # added 2020-04-28 jaw rt#8975
-seaguls seaguls.berkeley.edu
 seaguls seaguls.studentorg.berkeley.edu
 
 # added 2020-04-28 jaw rt#9040
-thetatau thetatau.berkeley.edu
 thetatau thetatau.studentorg.berkeley.edu
 
 # added 2020-04-28 jaw rt#9039
-grotech grotech.berkeley.edu
 grotech grotech.studentorg.berkeley.edu
 
 # added 2020-04-23 jaw rt#9022
-ispe ispe.berkeley.edu
 ispe ispe.studentorg.berkeley.edu
 
 # added 2020-04-23 jaw rt#9034
-chemecar chemecar.berkeley.edu
 chemecar chemecar.studentorg.berkeley.edu
 
 # added 2020-04-23 jaw rt#9032
-calasce asce.berkeley.edu
 calasce asce.studentorg.berkeley.edu
 
 # added 2020-04-21 jaw rt#9029
-awe awe.berkeley.edu
 awe awe.studentorg.berkeley.edu
 
 # added 2020-04-19 jaw rt#8997 rt#9027
-bamlab bamlab.berkeley.edu
 bamlab bamlab.studentorg.berkeley.edu
 
 # added 2020-03-14 jaw rt#8927 pending name change
 # update 2020-0324 minos - still pending name change
 # update 2020-04-17 jaw confirmed
-shack shac.berkeley.edu
 shack shac.studentorg.berkeley.edu
 
 # added 2020-04-16 jaw rt#9006
-spaceenterprise seb.berkeley.edu
 spaceenterprise seb.studentorg.berkeley.edu
 
 # added 2020-04-13 jaw rt#9000
-blueprint blueprint.berkeley.edu
 blueprint blueprint.studentorg.berkeley.edu
 
 # added 2020-04-12 jaw rt#9001
-ansberkeley ans.berkeley.edu
 ansberkeley ans.studentorg.berkeley.edu
 
 # added 2020-04-10 jaw rt#8998
-swe swe.berkeley.edu
 swe swe.studentorg.berkeley.edu
 
 # added 2020-04-07 jaw rt#8992
-psr psr.berkeley.edu
 psr psr.studentorg.berkeley.edu
 
 # added 2020-04-06 kmo rt#8990
-calsmv smv.berkeley.edu
 calsmv smv.studentorg.berkeley.edu
 
 # added 2020-03-04 vio in-person
-tassellink tassellink.berkeley.edu
 tassellink tassellink.studentorg.berkeley.edu
 
 # addded 2020-03-01 minos in-person
-auvs urobotics.berkeley.edu
 auvs urobotics.studentorg.berkeley.edu
 
 # addded 2020-02-26 jaw rt#8857
-skynx skynx.berkeley.edu
 skynx skynx.studentorg.berkeley.edu
 
 # added 2020-02-26 jaw rt#8874
-hyperloop ev.berkeley.edu
 hyperloop ev.studentorg.berkeley.edu
 
 # added 2020-02-24 snarain in-person
-plextech plextech.berkeley.edu
 plextech plextech.studentorg.berkeley.edu
 
 # added 2020-02-22 jaw rt#8856
-accelerateher accelerateher.berkeley.edu
 accelerateher accelerateher.studentorg.berkeley.edu
 
 # added 2020-02-20 jaw rt#8850
-pcs pcs.berkeley.edu
 pcs pcs.studentorg.berkeley.edu
 
 # added 2020-02-20 fydai in-persion
-businessreview businessreview.berkeley.edu
 businessreview businessreview.studentorg.berkeley.edu
 
 # added 2020-02-16 cooperc rt#8584
-brasa brasa.berkeley.edu
 brasa brasa.studentorg.berkeley.edu
 
 # added 2020-02-07 jaw rt#8808
-techsocialimpact tsihacks.berkeley.edu
 techsocialimpact tsihacks.studentorg.berkeley.edu
 
 # added 2020-02-07 cooperc in-person
 # updated 2020-02-16 cooperc rt#8807
-alzheimers alzassociation.berkeley.edu
 alzheimers alzassociation.studentorg.berkeley.edu
 
 # added 2020-02-06 jaw in-person
-btnberkeley btn.berkeley.edu
 btnberkeley btn.studentorg.berkeley.edu
 
 # added 2020-01-31 cooperc in-person
-pts pts.berkeley.edu
 pts pts.studentorg.berkeley.edu
 
 #added 2020-01-30 fydai rt#8681
 # fixed cooperc 2020-02-11
-rrrc raices.berkeley.edu
 rrrc raices.studentorg.berkeley.edu
 
 #added 2020-01-28 jaw rt#8785
-bbi bbi.berkeley.edu
 bbi bbi.studentorg.berkeley.edu
 
 # added 2020-01-24 jaw rt#8767
-vcb vc.berkeley.edu
 vcb vc.studentorg.berkeley.edu
 
 # added 2020-01-19 jaw rt#8749
-bridges bridges.berkeley.edu
 bridges bridges.studentorg.berkeley.edu
 
 # added 2020-01-18 jaw rt#8745
 # update 2020-01-22 cooperc rt#8760
-movefellowship movefellowship.berkeley.edu
 movefellowship movefellowship.studentorg.berkeley.edu
 
 # added 2019-12-05 abizer rt#8699
-aua aua.berkeley.edu
 aua aua.studentorg.berkeley.edu
 
 # added 2019-11-26 dkessler rt#8623
-bearconnections bearconnections.berkeley.edu
 bearconnections bearconnections.studentorg.berkeley.edu
 
 # added 2019-11-03 tonylian in-person
-bcssa bcssa.berkeley.edu
 bcssa bcssa.studentorg.berkeley.edu
 
 # added 2019-10-21 cooperc in-person
-sro sro.berkeley.edu
 sro sro.studentorg.berkeley.edu
 
 # added 2019-10-15 fydai rt#8538
-boaa boaa.berkeley.edu
 boaa boaa.studentorg.berkeley.edu
 
 # added 2019-10-14 cooperc in-person
-nscb nscb.berkeley.edu
 nscb nscb.studentorg.berkeley.edu
 
 # added 2019-09-23 abizer rt#8523
-barestge barestage.berkeley.edu
 barestge barestage.studentorg.berkeley.edu
 
 # added 2019-09-23 minos in-person
-uav uavs.berkeley.edu
 uav uavs.studentorg.berkeley.edu
 
 # added 2019-09-09 minos in-person
-uav aerobear.berkeley.edu
 uav aerobear.studentorg.berkeley.edu
 
 # added 2019-09-05 abizer rt#8441
-vrab xr.berkeley.edu
 vrab xr.studentorg.berkeley.edu
 
 # added 2019-08-29 adityasri rt#8454
-bicycal bicycal.berkeley.edu
 bicycal bicycal.studentorg.berkeley.edu
 
 # added 2019-08-28 abizer rt#8446
-bipla privlab.berkeley.edu
 bipla privlab.studentorg.berkeley.edu
 
 # added 2019-08-16 abizer rt#8415
-appnet appnet.berkeley.edu
 appnet appnet.studentorg.berkeley.edu
 
 # added 2019-08-06 adityasri rt#8394
-hurling hurling.berkeley.edu
 hurling hurling.studentorg.berkeley.edu
 
 # added 2019-05-20 seanvernon in-person
-ucbmun bearmun.berkeley.edu
 ucbmun bearmun.studentorg.berkeley.edu
 
 # added 2019-05-14 dkessler rt#8277
-dancethebay dancethebay.berkeley.edu
 dancethebay dancethebay.studentorg.berkeley.edu
 
 # added 2019-04-16 abizer rt#8199
-bridgeyear bridgeyear.berkeley.edu
 bridgeyear bridgeyear.studentorg.berkeley.edu
 
 # added 2019-04-13 minos in-person
-uav autocal.berkeley.edu
 uav autocal.studentorg.berkeley.edu
 
 # added 2019-04-11 cooperc rt#8185
-hcg hcg.berkeley.edu
 hcg hcg.studentorg.berkeley.edu
 
 # added 2019-04-01 dkessler rt#8152
-lasr lasr.berkeley.edu
 lasr lasr.studentorg.berkeley.edu
 
 # added 2019-03-21 dkessler in-person
-mlo mlo.berkeley.edu
 mlo mlo.studentorg.berkeley.edu
 
 #added 2019-03-18 abizer in-person
-aurum aurum.berkeley.edu
 aurum aurum.studentorg.berkeley.edu
 
 # added 2019-03-13 abizer in-person
-toppa toppa.berkeley.edu
 toppa toppa.studentorg.berkeley.edu
 
 # added 2019-02-28 keur in person
-invent inventabroad.berkeley.edu
 invent inventabroad.studentorg.berkeley.edu
 
 # added 2019-02-26 abizer rt#8055
-hyperloop hyperloop.berkeley.edu
 hyperloop hyperloop.studentorg.berkeley.edu
 
 # added 2019-02
-mri mri.berkeley.edu
 mri mri.studentorg.berkeley.edu
 
 # added 2019-02-09 dkessler rt#7997
-tbp tbp.berkeley.edu
 tbp tbp.studentorg.berkeley.edu
 
 # added 2019-02-05 dkessler rt#7996
-giant giantfilmmakers.berkeley.edu
 giant giantfilmmakers.studentorg.berkeley.edu
 
 # added 2019-02-05 abizer rt#7999
-seedofhealth bmri.berkeley.edu
 seedofhealth bmri.studentorg.berkeley.edu
 
 # added 2019-02-01 cooperc in-person
-history phat.berkeley.edu
 history phat.studentorg.berkeley.edu
 
 # added 2019-01-27 dkessler rt#7970
-laya laya.berkeley.edu
 laya laya.studentorg.berkeley.edu
 
 # added 2019-01-18 seanvernon in-person
-ucbmun mun.berkeley.edu
 ucbmun mun.studentorg.berkeley.edu
 # added 2019-04-18 cooperc in-person
 # non berkeley.edu approved by cooperc
 ucbmun ucbmun.org
 
 # added 2019-01-16 abizer rt#7932
-pasae pasae.berkeley.edu
 pasae pasae.studentorg.berkeley.edu
 
 # added 2019-01-13 abizer rt#7923
-ownit ownit.berkeley.edu
 ownit ownit.studentorg.berkeley.edu
 
 # added 2018-11-24 dkessler rt#7828
-databears db.berkeley.edu
 databears db.studentorg.berkeley.edu
 
 # added 2018-11-07 keur in-person
-epsilonpi epsilonpi.berkeley.edu
 epsilonpi epsilonpi.studentorg.berkeley.edu
 
 # added 2018-11-07 keur in-person
-ses ses.berkeley.edu
 ses ses.studentorg.berkeley.edu
 
 # added 2018-11-07 keur in-person
-bearwolf bgb.berkeley.edu
 bearwolf bgb.studentorg.berkeley.edu
 
 # added 2018-10-29 dkessler rt#7717
-breathe breathe.berkeley.edu
 breathe breathe.studentorg.berkeley.edu
 
 # added 2018-10-18 dkessler rt#7716
-rohp rohp.berkeley.edu
 rohp rohp.studentorg.berkeley.edu
 
 # added 2018-10-26 dkessler rt#7708
-beyond beyondacademia.berkeley.edu
 beyond beyondacademia.studentorg.berkeley.edu
 
 # added 2018-10-22 abizer rt#7694
-krober kas.berkeley.edu
 krober kas.studentorg.berkeley.edu
 
 # added 2018-10-18 mdcha in-person
-brb bail.berkeley.edu
 brb bail.studentorg.berkeley.edu
 
 # added 2018-10-15 dkessler rt#7676
-circlek cki.berkeley.edu
 circlek cki.studentorg.berkeley.edu
 
 # added 2018-10-13 abizer rt#7644
-bapscampus bcf.berkeley.edu
 bapscampus bcf.studentorg.berkeley.edu
 
 # added 2018-9-29 bchieng (in person)
-qtsab qtsab.berkeley.edu
 qtsab qtsab.studentorg.berkeley.edu
 
 # added 2018-09-29 abizer rt#7624
-reach reach.berkeley.edu
 reach reach.studentorg.berkeley.edu
 
 # added 2018-09-25 seanvernon rt#7616
-urec urec.berkeley.edu
 urec urec.studentorg.berkeley.edu
 
 # added 2018-09-12 mdcha (staff hours)
-neurotech neurotech.berkeley.edu
 neurotech neurotech.studentorg.berkeley.edu
 
 # added 2018-09-20 dkessler (staff hours)
-epoch epoch.berkeley.edu
 epoch epoch.studentorg.berkeley.edu
 # changed 2019-10-13 php (in person)
-epoch pdab.berkeley.edu
 epoch pdab.studentorg.berkeley.edu
 
 # added 2018-09-12 mdcha (staff hours)
-mmhi mmhi.berkeley.edu
 mmhi mmhi.studentorg.berkeley.edu
 
 # added 2018-09-11 dkessler rt#7568
-sasc sasc.berkeley.edu
 sasc sasc.studentorg.berkeley.edu
 
 # added 2018-09-04 keur rt#7325
 hackthebay calhacks.io
 
 # added 2018-08-30 dkessler rt#7536
-mtab mtab.berkeley.edu
 mtab mtab.studentorg.berkeley.edu
 
 # added 2018-08-28 mdcha (in person)
-calop fiatlux.berkeley.edu
 calop fiatlux.studentorg.berkeley.edu
 
 # added 2018-08-28 abizer rt#7514
-engle e98.berkeley.edu
 engle e98.studentorg.berkeley.edu
 
 # added 2018-08-22 abizer rt#7500
-dabestlab edens.berkeley.edu
 dabestlab edens.studentorg.berkeley.edu
 
 # added 2018-08-17 abizer rt#7477
-itsdecal introtosurgery.berkeley.edu
 itsdecal introtosurgery.studentorg.berkeley.edu
 
 # added 2018-07-31 abizer rt#7457
-ctennis bta.berkeley.edu
 ctennis bta.studentorg.berkeley.edu
 
 # added 2018-07-10 keur #rt7406
-idegroup ide.berkeley.edu
 idegroup ide.studentorg.berkeley.edu
 
 # added 2018-06-19 rt#7395
-pass pass.berkeley.edu
 pass pass.studentorg.berkeley.edu
 
 # added 2018-06-01 wporr
 # changed rt#9489
-gamecraft gamedev.berkeley.edu
 gamecraft gamedev.studentorg.berkeley.edu
 
 # added 2018-05-20 abizer
-vss venture.berkeley.edu
 vss venture.studentorg.berkeley.edu
 
 # 2018-05-18 rt#7342 wporr
-ewb ewb.berkeley.edu
 ewb ewb.studentorg.berkeley.edu
 
 # 2018-05-04 rt#7314 jvperrin
-isa isa.berkeley.edu
 isa isa.studentorg.berkeley.edu
 
 # 2018-05-01 rt#7295 bzh
-construction constructionteam.berkeley.edu
 construction constructionteam.studentorg.berkeley.edu
 
 # 2018-03-26 rt#7216 dkessler
-utk utk.berkeley.edu
 utk utk.studentorg.berkeley.edu
 
 # 2018-03-23 (staff hours) keur
-ahub ahlulbaytsociety.berkeley.edu
 ahub ahlulbaytsociety.studentorg.berkeley.edu
 
 # 2018-03-12 rt#7185 bzh
-eatb entrepreneurs.berkeley.edu
 eatb entrepreneurs.studentorg.berkeley.edu
 
 # 2018-03-03 rt#7165
-chec chec.berkeley.edu
 chec chec.studentorg.berkeley.edu
 
 # 2018-03-08 rt#7172 keur
-nicugroup nicu.berkeley.edu
 nicugroup nicu.studentorg.berkeley.edu
 
 # 2018-02-22 rt#7121 abizer
-bpreview bpr.berkeley.edu
 bpreview bpr.studentorg.berkeley.edu
 
 # 2018-02-07 (in person) jvperrin
-neri neurolab.berkeley.edu
 neri neurolab.studentorg.berkeley.edu
 
 # 2018-02-06 rt#7059 abizer
-qcb qcb.berkeley.edu
 qcb qcb.studentorg.berkeley.edu
 
 # 2018-01-26 rt#7015 keur
-dsi dsi.berkeley.edu
 dsi dsi.studentorg.berkeley.edu
 
 # 2018-01-23 rt#6996 abizer
-beacn beacn.berkeley.edu
 beacn beacn.studentorg.berkeley.edu
 
 # 2018-01-16 rt#6952 abizer
-berkeleet berke1337.berkeley.edu
 berkeleet berke1337.studentorg.berkeley.edu
 
 # 2018-01-16 rt#6951 abizer
-caltv caltv.berkeley.edu
 caltv caltv.studentorg.berkeley.edu
 
 # 2018-01-16 rt#6949 abizer
-mccb mccb.berkeley.edu
 mccb mccb.studentorg.berkeley.edu
 
 # 2018-01-15 rt#6907 abizer
-bioprinting bioprinting.berkeley.edu
 bioprinting bioprinting.studentorg.berkeley.edu
 
 # 2018-01-05 rt#6929 abizer
-calite ite.berkeley.edu
 calite ite.studentorg.berkeley.edu
 
 # 2017-12-25 rt#6919 keur
-bppj bppj.berkeley.edu
 bppj bppj.studentorg.berkeley.edu
 
 # 2017-11-30 rt#6867 abizer
-lipb ulhs.berkeley.edu
 lipb ulhs.studentorg.berkeley.edu
 
 # 2017-11-29 rt#6863 chuang
-moveme moveme.berkeley.edu
 moveme moveme.studentorg.berkeley.edu
 
 # 2017-11-29 rt#6860 keur
-bhi bhi.berkeley.edu
 bhi bhi.studentorg.berkeley.edu
 
 # 2017-11-21 rt#6841 keur
-ace ace.berkeley.edu
 ace ace.studentorg.berkeley.edu
 
 # 2017-11-06 rt#6780 keur
-geostudents geostudents.berkeley.edu
 geostudents geostudents.studentorg.berkeley.edu
 
 # 2017-11-01 rt#6767 abizer
-sheleads sheleads.berkeley.edu
 sheleads sheleads.studentorg.berkeley.edu
 
 # 207-10-30 rt#6736 abizer
-sciencepolicy sciencepolicy.berkeley.edu
 sciencepolicy sciencepolicy.studentorg.berkeley.edu
 
 # 2017-10-27 rt#6727 ckuehl
-sinmaysa ssa.berkeley.edu
 sinmaysa ssa.studentorg.berkeley.edu
 
 # 2017-10-20 rt#6691 abizer
-efork e4k.berkeley.edu
 efork e4k.studentorg.berkeley.edu
 
 # 2017-10-19 rt#6675 abizer
-terraetc terra.berkeley.edu
 terraetc terra.studentorg.berkeley.edu
 
 # 2017-10-19 rt#6682 abizer
-gdso gdso.berkeley.edu
 gdso gdso.studentorg.berkeley.edu
 
 # 2017-10-05 rt#6647 kpengboy
-helios helios.berkeley.edu
 helios helios.studentorg.berkeley.edu
 
 # 2017-09-25 rt#6622 abizer
-pha pha.berkeley.edu
 pha pha.studentorg.berkeley.edu
 
 # 2017-09-24 rt#6616 abizer
-dssb dss.berkeley.edu
 dssb dss.studentorg.berkeley.edu
 
 # 2017-09-09 rt#6531 abizer
-icb icb.berkeley.edu
 icb icb.studentorg.berkeley.edu
 
 # 2017-08-25 rt#6454 ckuehl
 # changed rt#9252
-ssscr tmsca.berkeley.edu
 ssscr tmsca.studentorg.berkeley.edu
 
 # 2017-08-25 rt#6449 abizer
-ushp ushp.berkeley.edu
 ushp ushp.studentorg.berkeley.edu
 
 # 2017-08-21 rt#6418 abizer
-ssc ssc.berkeley.edu
 ssc ssc.studentorg.berkeley.edu
 
 # 2017-08-14 rt#6417 abizer
 # 2018-08-28 rt#8444 abizer susa renamed to saas
 # jaw: removed old susa domain
-ugradsa saas.berkeley.edu
 ugradsa saas.studentorg.berkeley.edu
 
 # 2017-08-11 (self) abizer
 decal decal.ocf.berkeley.edu
 
 # 2017-07-20 rt#6377 abizer
-debsoc debate.berkeley.edu
 debsoc debate.studentorg.berkeley.edu
 
 # 2017-07-12 rt#6327 abizer
-calsteel steelbridge.berkeley.edu
 calsteel steelbridge.studentorg.berkeley.edu
 
-aacf aacf.berkeley.edu
 aacf aacf.studentorg.berkeley.edu
-aez aez.berkeley.edu
 aez aez.studentorg.berkeley.edu
-aiaa aiaa.berkeley.edu
 aiaa aiaa.studentorg.berkeley.edu
-alumni casa.berkeley.edu
 alumni casa.studentorg.berkeley.edu
-analytic aoc.berkeley.edu
 analytic aoc.studentorg.berkeley.edu
-archery archery.berkeley.edu
 archery archery.studentorg.berkeley.edu
-asme asme.berkeley.edu
 asme asme.studentorg.berkeley.edu
-backgammon blb.berkeley.edu
 backgammon blb.studentorg.berkeley.edu
-badmintn badminton.berkeley.edu
 badmintn badminton.studentorg.berkeley.edu
-bcab bcab.berkeley.edu
 bcab bcab.studentorg.berkeley.edu
-bconsult bc.berkeley.edu
 bconsult bc.studentorg.berkeley.edu
-bforum forum.berkeley.edu
 bforum forum.studentorg.berkeley.edu
-bforum forum.berkeley.edu
 bforum forum.studentorg.berkeley.edu
-bioehs bioehs.berkeley.edu
 bioehs bioehs.studentorg.berkeley.edu
-bitcoin bitcoin.berkeley.edu
 bitcoin bitcoin.studentorg.berkeley.edu
-bitcoin blockchain.berkeley.edu
 bitcoin blockchain.studentorg.berkeley.edu
-bluegold yearbook.berkeley.edu
 bluegold yearbook.studentorg.berkeley.edu
-bpg bpsychologygroup.berkeley.edu
 bpg bpsychologygroup.studentorg.berkeley.edu
-breadclub bread.berkeley.edu
 breadclub bread.studentorg.berkeley.edu
-calconst calconstruction.berkeley.edu
 calconst calconstruction.studentorg.berkeley.edu
-caleague actuary.berkeley.edu
 caleague actuary.studentorg.berkeley.edu
-cglc cglc.berkeley.edu
 cglc cglc.studentorg.berkeley.edu
-choral ucchoral.berkeley.edu
 choral ucchoral.studentorg.berkeley.edu
-choral ucchoral.berkeley.edu
 choral ucchoral.studentorg.berkeley.edu
-cia invest.berkeley.edu
 cia invest.studentorg.berkeley.edu
-codebase codebase.berkeley.edu
 codebase codebase.studentorg.berkeley.edu
-cssa cssa.berkeley.edu
 cssa cssa.studentorg.berkeley.edu
-cycling cycling.berkeley.edu
 cycling cycling.studentorg.berkeley.edu
-diabears d1abears.berkeley.edu
 diabears d1abears.studentorg.berkeley.edu
-dts drawntoscale.berkeley.edu
 dts drawntoscale.studentorg.berkeley.edu
-eau eau.berkeley.edu
 eau eau.studentorg.berkeley.edu
-eerlab eerlab.berkeley.edu
 eerlab eerlab.studentorg.berkeley.edu
-ejc esc.berkeley.edu
 ejc esc.studentorg.berkeley.edu
-eleven eleven.berkeley.edu
 eleven eleven.studentorg.berkeley.edu
-enablet enabletech.berkeley.edu
 enablet enabletech.studentorg.berkeley.edu
-enactus enactus.berkeley.edu
 enactus enactus.studentorg.berkeley.edu
-eswb esw.berkeley.edu
 eswb esw.studentorg.berkeley.edu
 ethical ethicalapparel.org
-ewb ewb.berkeley.edu
 ewb ewb.studentorg.berkeley.edu
-feed feed.berkeley.edu
 feed feed.studentorg.berkeley.edu
-foodinno foodinno.berkeley.edu
 foodinno foodinno.studentorg.berkeley.edu
-foodsci fst.berkeley.edu
 foodsci fst.studentorg.berkeley.edu
-hmap hmap.berkeley.edu
 hmap hmap.studentorg.berkeley.edu
-hsab hsab.berkeley.edu
 hsab hsab.studentorg.berkeley.edu
-igs igenspectrum.berkeley.edu
 igs igenspectrum.studentorg.berkeley.edu
-isab isab.berkeley.edu
 isab isab.studentorg.berkeley.edu
-isac isac.berkeley.edu
 isac isac.studentorg.berkeley.edu
-ixic ixic.berkeley.edu
 ixic ixic.studentorg.berkeley.edu
-karate karate.berkeley.edu
 karate karate.studentorg.berkeley.edu
-knowyouruni knowyouruniversity.berkeley.edu
 knowyouruni knowyouruniversity.studentorg.berkeley.edu
-mlab ml.berkeley.edu
 mlab ml.studentorg.berkeley.edu
-morningsignout morningsignout.berkeley.edu
 morningsignout morningsignout.studentorg.berkeley.edu
-msa msa.berkeley.edu
 msa msa.studentorg.berkeley.edu
-msea msea.berkeley.edu
 msea msea.studentorg.berkeley.edu
-mto sufiassociation.berkeley.edu
 mto sufiassociation.studentorg.berkeley.edu
-nib nib.berkeley.edu
 nib nib.studentorg.berkeley.edu
-nsls nsls.berkeley.edu
 nsls nsls.studentorg.berkeley.edu
-nsu nsu.berkeley.edu
 nsu nsu.studentorg.berkeley.edu
-nutmeg nutmeg.berkeley.edu
 nutmeg nutmeg.studentorg.berkeley.edu
-oai oa.berkeley.edu
 oai oa.studentorg.berkeley.edu
-onehundredstrong onehundredstrong.berkeley.edu
 onehundredstrong onehundredstrong.studentorg.berkeley.edu
-pcg phoenix.berkeley.edu
 pcg phoenix.studentorg.berkeley.edu
-perspect perspective.berkeley.edu
 perspect perspective.studentorg.berkeley.edu
-pmhs pmhs.berkeley.edu
 pmhs pmhs.studentorg.berkeley.edu
-pokemon pkmn.berkeley.edu
 pokemon pkmn.studentorg.berkeley.edu
-polish polishclub.berkeley.edu
 polish polishclub.studentorg.berkeley.edu
-ppgs fly.berkeley.edu
 ppgs fly.studentorg.berkeley.edu
 projectscifi projectscifi.org
-ptps ptps.berkeley.edu
 ptps ptps.studentorg.berkeley.edu
-quiparle quiparle.berkeley.edu
 quiparle quiparle.studentorg.berkeley.edu
-recycle recycle.berkeley.edu
 recycle recycle.studentorg.berkeley.edu
-reuse reuse.berkeley.edu
 reuse reuse.studentorg.berkeley.edu
-robobears robobears.berkeley.edu
 robobears robobears.studentorg.berkeley.edu
-robotics rab.berkeley.edu
 robotics rab.studentorg.berkeley.edu
 
 #CNAME only, plus changing to raices.be
 #see rt#8681 -cooperc
 #rrrc raza.berkeley.edu
 
-rtsa rtsa.berkeley.edu
 rtsa rtsa.studentorg.berkeley.edu
-sailing sailing.berkeley.edu
 sailing sailing.studentorg.berkeley.edu
-sca sca.berkeley.edu
 sca sca.studentorg.berkeley.edu
-scc seniorclasscouncil.berkeley.edu
 scc seniorclasscouncil.studentorg.berkeley.edu
-sesb sesb.berkeley.edu
 sesb sesb.studentorg.berkeley.edu
-see see.berkeley.edu
 see see.studentorg.berkeley.edu
-sigma axs.berkeley.edu
 sigma axs.studentorg.berkeley.edu
-skiteam skiteam.berkeley.edu
 skiteam skiteam.studentorg.berkeley.edu
-songwriting songwriting.berkeley.edu
 songwriting songwriting.studentorg.berkeley.edu
-speech speech.berkeley.edu
 speech speech.studentorg.berkeley.edu
-spie photobears.berkeley.edu
 spie photobears.studentorg.berkeley.edu
 squelch squelched.com
-stac stac.berkeley.edu
 stac stac.studentorg.berkeley.edu
-startup startup.berkeley.edu
 startup startup.studentorg.berkeley.edu
-uaem uaem.berkeley.edu
 uaem uaem.studentorg.berkeley.edu
-uav uav.berkeley.edu
 uav uav.studentorg.berkeley.edu
-uea econreview.berkeley.edu
 uea econreview.studentorg.berkeley.edu
-ulab ulab.berkeley.edu
 ulab ulab.studentorg.berkeley.edu
-unab unab.berkeley.edu
 unab unab.studentorg.berkeley.edu
-unicef unicef.berkeley.edu
 unicef unicef.studentorg.berkeley.edu
-unrac unrac.berkeley.edu
 unrac unrac.studentorg.berkeley.edu
 upe upe.berkeley.edu
 upe upe.cs.berkeley.edu
-vcb vcb.berkeley.edu
 vcb vcb.studentorg.berkeley.edu
-vcg vcg.berkeley.edu
 vcg vcg.studentorg.berkeley.edu
-vhio vhio.berkeley.edu
 vhio vhio.studentorg.berkeley.edu
-vmo vmo.berkeley.edu
 vmo vmo.studentorg.berkeley.edu
-vrab vr.berkeley.edu
 vrab vr.studentorg.berkeley.edu
-wsladmin wordsoundlife.berkeley.edu
 wsladmin wordsoundlife.studentorg.berkeley.edu

--- a/configs/vhost-mail.conf
+++ b/configs/vhost-mail.conf
@@ -16,6 +16,7 @@ spaceformgroup spaceform.studentorg.berkeley.edu
 
 # rt#13141
 asrb asrb.berkeley.edu
+asrb asrb.studentorg.berkeley.edu
 
 # rt#13376
 ghibligradguild ghibligradguild.studentorg.berkeley.edu
@@ -52,897 +53,1249 @@ thebp berkeleyproject.org
 
 # rt#12875
 gwenn seismic.berkeley.edu
+gwenn seismic.studentorg.berkeley.edu
 
 # rt#12837
 substrate substratelabs.dev
 
 # rt#12764
 slugs slugs.berkeley.edu
+slugs slugs.studentorg.berkeley.edu
 
 # rt#11915
 powerbayarea powerbayarea.berkeley.edu
+powerbayarea powerbayarea.studentorg.berkeley.edu
 
 # rt#11851
 bsgsa bsgsa.berkeley.edu
+bsgsa bsgsa.studentorg.berkeley.edu
 
 # rt#11825
 sis southindiansociety.berkeley.edu
+sis southindiansociety.studentorg.berkeley.edu
 
 # rt#11663
 hsc hsc.berkeley.edu
+hsc hsc.studentorg.berkeley.edu
 
 # rt#11600
 bessa bessa.berkeley.edu
+bessa bessa.studentorg.berkeley.edu
 
 # rt#11572
 sensibility sensibility.berkeley.edu
+sensibility sensibility.studentorg.berkeley.edu
 
 # rt#11537
 calcodeology codeology.berkeley.edu
+calcodeology codeology.studentorg.berkeley.edu
 
 # rt#11546
 beam beam.berkeley.edu
+beam beam.studentorg.berkeley.edu
 
 # rt#11530
 bioscienceallian biox.berkeley.edu
+bioscienceallian biox.studentorg.berkeley.edu
 
 # rt#11482
 enviro enviroteam.berkeley.edu
+enviro enviroteam.studentorg.berkeley.edu
 
 # rt#11440
 cqg cqg.berkeley.edu
+cqg cqg.studentorg.berkeley.edu
 
 # rt#11381
 pab pab.berkeley.edu
+pab pab.studentorg.berkeley.edu
 
 # rt#11295
 pmh pawsformentalhealth.berkeley.edu
+pmh pawsformentalhealth.studentorg.berkeley.edu
 
 # rt#11302
 fedchallenge fedchallenge.berkeley.edu
+fedchallenge fedchallenge.studentorg.berkeley.edu
 
 # rt#11247
 globalinvestors globalinvestors.berkeley.edu
+globalinvestors globalinvestors.studentorg.berkeley.edu
 
 # rt#11026
 skateboarding skateboarding.berkeley.edu
+skateboarding skateboarding.studentorg.berkeley.edu
 
 # rt#11220
 fourdcapital 4dcapital.berkeley.edu
+fourdcapital 4dcapital.studentorg.berkeley.edu
 
 # rt#11215
 eggster eggster.berkeley.edu
+eggster eggster.studentorg.berkeley.edu
 
 # rt#11058
 blit blit.berkeley.edu
+blit blit.studentorg.berkeley.edu
 
 # rt#11035
 calttc calttc.berkeley.edu
+calttc calttc.studentorg.berkeley.edu
 
 # rt#11005
 cluj cluj.berkeley.edu
+cluj cluj.studentorg.berkeley.edu
 
 # rt#10967
 capclub capclub.berkeley.edu
+capclub capclub.studentorg.berkeley.edu
 
 # rt#10942
 bmf mfb.berkeley.edu
+bmf mfb.studentorg.berkeley.edu
 
 # rt#10898
 inm inm.berkeley.edu
+inm inm.studentorg.berkeley.edu
 
 # rt#10889
 calproductspace product.berkeley.edu
+calproductspace product.studentorg.berkeley.edu
 
 # rt#10868
 eecsdiscord eecsdiscord.berkeley.edu
+eecsdiscord eecsdiscord.studentorg.berkeley.edu
 
 # rt#10432
 information asl.berkeley.edu
+information asl.studentorg.berkeley.edu
 
 # rt#10572
 afghans calasa.berkeley.edu
+afghans calasa.studentorg.berkeley.edu
 
 # rt#10606
 figc figc.berkeley.edu
+figc figc.studentorg.berkeley.edu
 
 # rt#10619
 legends legends.berkeley.edu
+legends legends.studentorg.berkeley.edu
 
 # rt#10605
 fightinggames fightinggames.berkeley.edu
+fightinggames fightinggames.studentorg.berkeley.edu
 
 # rt#10380
 btc btc.berkeley.edu
+btc btc.studentorg.berkeley.edu
 
 # rt#10587
 ifb ifb.berkeley.edu
+ifb ifb.studentorg.berkeley.edu
 
 # rt#10544
 grepml grepml.berkeley.edu
+grepml grepml.studentorg.berkeley.edu
 
 # staff hours (migrating to calico.cs.b.e)
 calico calico.cs.berkeley.edu
 
 # rt#10523
 calico calico.berkeley.edu
+calico calico.studentorg.berkeley.edu
 
 # rt#10387
 bikebuilders bikebuilders.berkeley.edu
+bikebuilders bikebuilders.studentorg.berkeley.edu
 
 # rt#10334
 qarc queer.berkeley.edu
+qarc queer.studentorg.berkeley.edu
 qarc qarc.berkeley.edu
+qarc qarc.studentorg.berkeley.edu
 
 # rt#10371
 transpo transpo.berkeley.edu
+transpo transpo.studentorg.berkeley.edu
 
 # rt#10286
 ujpb ujpb.berkeley.edu
+ujpb ujpb.studentorg.berkeley.edu
 
 # rt#10084
 mixed mixed.berkeley.edu
+mixed mixed.studentorg.berkeley.edu
 
 # rt#10127
 aarj aarj.berkeley.edu
+aarj aarj.studentorg.berkeley.edu
 
 # rt#10004
 powerandenergy powerandenergy.berkeley.edu
+powerandenergy powerandenergy.studentorg.berkeley.edu
 
 # staff hours + rt#10020
 mpasforempower mpa4je.berkeley.edu
+mpasforempower mpa4je.studentorg.berkeley.edu
 
 # rt#10083
 horrorhouse horrorhouse.berkeley.edu
+horrorhouse horrorhouse.studentorg.berkeley.edu
 
 # rt#10047
 traders traders.berkeley.edu
+traders traders.studentorg.berkeley.edu
 
 # rt#10011
 paneltothepeople p2tp.berkeley.edu
+paneltothepeople p2tp.studentorg.berkeley.edu
 
 # staff hours
 disabilitylab disability.berkeley.edu
+disabilitylab disability.studentorg.berkeley.edu
 
 # rt#9924
 citizensclimate citizensclimate.berkeley.edu
+citizensclimate citizensclimate.studentorg.berkeley.edu
 
 # rt#9874
 policy policy.berkeley.edu
+policy policy.studentorg.berkeley.edu
 
 # rt#9835
 philforum philforum.berkeley.edu
+philforum philforum.studentorg.berkeley.edu
 
 # rt#9831
 physics sps.berkeley.edu
+physics sps.studentorg.berkeley.edu
 
 # in-person
 thaisa thaisa.berkeley.edu
+thaisa thaisa.studentorg.berkeley.edu
 
 # rt#9789
 ioc ioc.berkeley.edu
+ioc ioc.studentorg.berkeley.edu
 
 # rt#9761
 surg surg.berkeley.edu
+surg surg.studentorg.berkeley.edu
 
 # rt#9730
 megsco megsco.berkeley.edu
+megsco megsco.studentorg.berkeley.edu
 
 # rt#9753
 kmoverse kmo.berkeley.edu
+kmoverse kmo.studentorg.berkeley.edu
 
 # rt#9644
 exsurgo exsurgo.berkeley.edu
+exsurgo exsurgo.studentorg.berkeley.edu
 
 # rt#9677
 statusa susa.berkeley.edu
+statusa susa.studentorg.berkeley.edu
 
 # rt#9671
-amanecer amanecer.Berkeley.EDU
+amanecer amanecer.berkeley.edu
+amanecer amanecer.studentorg.berkeley.edu
 
 # rt#9605
-sky skyhappiness.Berkeley.EDU
+sky skyhappiness.berkeley.edu
+sky skyhappiness.studentorg.berkeley.edu
 
 # rt#9513
-prytanean prytanean.Berkeley.EDU
+prytanean prytanean.berkeley.edu
+prytanean prytanean.studentorg.berkeley.edu
 
 # rt#9622
-menaspla menaspla.Berkeley.EDU
+menaspla menaspla.berkeley.edu
+menaspla menaspla.studentorg.berkeley.edu
 
 # rt#11746
 # rt#9598
-combatrobotics combatrobotics.Berkeley.EDU
+combatrobotics combatrobotics.berkeley.edu
+combatrobotics combatrobotics.studentorg.berkeley.edu
 
 # rt#9568
-mlo mlo.Berkeley.EDU
+mlo mlo.berkeley.edu
+mlo mlo.studentorg.berkeley.edu
 
 # rt#9568
-bmt bmt.Berkeley.EDU
+bmt bmt.berkeley.edu
+bmt bmt.studentorg.berkeley.edu
 bmt berkeley.mt
 
 # rt#9545
-nedc nedc.Berkeley.EDU
+nedc nedc.berkeley.edu
+nedc nedc.studentorg.berkeley.edu
 
 # rt#9537
-swagg swagg.Berkeley.EDU
+swagg swagg.berkeley.edu
+swagg swagg.studentorg.berkeley.edu
 
 # rt#9535
-rics rics.Berkeley.EDU
+rics rics.berkeley.edu
+rics rics.studentorg.berkeley.edu
 
 # rt#9396
-pie pioneers.Berkeley.EDU
+pie pioneers.berkeley.edu
+pie pioneers.studentorg.berkeley.edu
 
 # rt#9516
-consulting cschool.Berkeley.EDU
+consulting cschool.berkeley.edu
+consulting cschool.studentorg.berkeley.edu
 
 # rt#9518
-ngn ngn.Berkeley.EDU
+ngn ngn.berkeley.edu
+ngn ngn.studentorg.berkeley.edu
 
 # rt#9508
-cahpsa cahpsa.Berkeley.EDU
+cahpsa cahpsa.berkeley.edu
+cahpsa cahpsa.studentorg.berkeley.edu
 
 # rt#9506
-sspc sspc.Berkeley.EDU
+sspc sspc.berkeley.edu
+sspc sspc.studentorg.berkeley.edu
 
 # rt#9494
-cloudcomputing cloudcomputing.Berkeley.EDU
+cloudcomputing cloudcomputing.berkeley.edu
+cloudcomputing cloudcomputing.studentorg.berkeley.edu
 
 # rt#9486
-beeps beeps.Berkeley.EDU
+beeps beeps.berkeley.edu
+beeps beeps.studentorg.berkeley.edu
 
 # rt#9475
-brownissues brownissues.Berkeley.EDU
+brownissues brownissues.berkeley.edu
+brownissues brownissues.studentorg.berkeley.edu
 
 # rt#9478
-asae asae.Berkeley.EDU
+asae asae.berkeley.edu
+asae asae.studentorg.berkeley.edu
 
 # rt#9474
-aiche aiche.Berkeley.EDU
+aiche aiche.berkeley.edu
+aiche aiche.studentorg.berkeley.edu
 
 # rt#9465
-snahp snahp.Berkeley.EDU
+snahp snahp.berkeley.edu
+snahp snahp.studentorg.berkeley.edu
 
 # rt#9437
-deltaconsulting deltaconsulting.Berkeley.EDU
+deltaconsulting deltaconsulting.berkeley.edu
+deltaconsulting deltaconsulting.studentorg.berkeley.edu
 
 # rt#9439
-otd otd.Berkeley.EDU
+otd otd.berkeley.edu
+otd otd.studentorg.berkeley.edu
 
 # rt#9438
-uweb uweb.Berkeley.EDU
+uweb uweb.berkeley.edu
+uweb uweb.studentorg.berkeley.edu
 
 # rt#9423
-newvoters newvoters.Berkeley.EDU
+newvoters newvoters.berkeley.edu
+newvoters newvoters.studentorg.berkeley.edu
 
 # rt#9411
-ostem ostem.Berkeley.EDU
+ostem ostem.berkeley.edu
+ostem ostem.studentorg.berkeley.edu
 
 # rt#9391
-abetterway abetterway.Berkeley.EDU
+abetterway abetterway.berkeley.edu
+abetterway abetterway.studentorg.berkeley.edu
 
 # rt#9377
-healsca healsca.Berkeley.EDU
+healsca healsca.berkeley.edu
+healsca healsca.studentorg.berkeley.edu
 
 # rt#9353
 itot itot.berkeley.edu
+itot itot.studentorg.berkeley.edu
 
 # rt#9305
 space stars.berkeley.edu
+space stars.studentorg.berkeley.edu
 
 # rt#9341
 anova anova.berkeley.edu
+anova anova.studentorg.berkeley.edu
 
 # rt#9314
 isaa isaa.berkeley.edu
+isaa isaa.studentorg.berkeley.edu
 
 # rt#9334
 calasla asla.berkeley.edu
+calasla asla.studentorg.berkeley.edu
 
 # rt#9002
 suitcase suitcase.berkeley.edu
+suitcase suitcase.studentorg.berkeley.edu
 
 # rt#9311
 predents pds.berkeley.edu
+predents pds.studentorg.berkeley.edu
 
 # rt#9300
 datagood datagood.berkeley.edu
+datagood datagood.studentorg.berkeley.edu
 
 # rt#9286
 hes hes.berkeley.edu
+hes hes.studentorg.berkeley.edu
 
 # rt#9282
 connectcal connected.berkeley.edu
+connectcal connected.studentorg.berkeley.edu
 
 # rt#9279
 wdd wdd.berkeley.edu
+wdd wdd.studentorg.berkeley.edu
 
 # rt#9045
 seismic seismic.berkeley.edu
+seismic seismic.studentorg.berkeley.edu
 
 # rt#9275
 bsj bsj.berkeley.edu
+bsj bsj.studentorg.berkeley.edu
 
 # rt#9269
 igem igem.berkeley.edu
+igem igem.studentorg.berkeley.edu
 
 # rt#9255
 ume ume.berkeley.edu
+ume ume.studentorg.berkeley.edu
 
 # rt#9222
 calcanoe concretecanoe.berkeley.edu
+calcanoe concretecanoe.studentorg.berkeley.edu
 
 # rt#9219
 bigdata bd.berkeley.edu
+bigdata bd.studentorg.berkeley.edu
 
 # rt#9213
 espmgdc espmgdc.berkeley.edu
+espmgdc espmgdc.studentorg.berkeley.edu
 
 # rt#9207
 csks cs-kickstart.berkeley.edu
+csks cs-kickstart.studentorg.berkeley.edu
 
 # added 2020-06-22 jaw rt#9202
 fsae fsae.berkeley.edu
+fsae fsae.studentorg.berkeley.edu
 
 # added 2020-06-16 jaw rt#9125
 ysa ysa.berkeley.edu
+ysa ysa.studentorg.berkeley.edu
 
 # added 2020-06-16 jaw rt#9172
 gwe gwe.berkeley.edu
+gwe gwe.studentorg.berkeley.edu
 
 # added 2020-06-15 jaw rt#9193
 chiep xe.berkeley.edu
+chiep xe.studentorg.berkeley.edu
 
 # added 2020-06-12 minos in-person
 uav theprojectboom.org
 
 # added 2020-06-12 jaw rt#9175
 geowall geowall.berkeley.edu
+geowall geowall.studentorg.berkeley.edu
 
 # added 2020-06-06 jaw rt#9147
 launchpad launchpad.berkeley.edu
+launchpad launchpad.studentorg.berkeley.edu
 
 # added 2020-06-06 jaw rt#9145
 bearshare bearshare.berkeley.edu
+bearshare bearshare.studentorg.berkeley.edu
 
 # added 2020-06-02 jaw rt#9133
 slrpev slrpev.berkeley.edu
+slrpev slrpev.studentorg.berkeley.edu
 
 # added 2020-05-31 jaw rt#9124
 girlup girlup.berkeley.edu
+girlup girlup.studentorg.berkeley.edu
 
 # added 2020-05-27 jaw rt#9082
 fblapbl pbl.berkeley.edu
+fblapbl pbl.studentorg.berkeley.edu
 
 # added 2020-04-28 jaw rt#8975
 seaguls seaguls.berkeley.edu
+seaguls seaguls.studentorg.berkeley.edu
 
 # added 2020-04-28 jaw rt#9040
 thetatau thetatau.berkeley.edu
+thetatau thetatau.studentorg.berkeley.edu
 
 # added 2020-04-28 jaw rt#9039
 grotech grotech.berkeley.edu
+grotech grotech.studentorg.berkeley.edu
 
 # added 2020-04-23 jaw rt#9022
 ispe ispe.berkeley.edu
+ispe ispe.studentorg.berkeley.edu
 
 # added 2020-04-23 jaw rt#9034
 chemecar chemecar.berkeley.edu
+chemecar chemecar.studentorg.berkeley.edu
 
 # added 2020-04-23 jaw rt#9032
 calasce asce.berkeley.edu
+calasce asce.studentorg.berkeley.edu
 
 # added 2020-04-21 jaw rt#9029
 awe awe.berkeley.edu
+awe awe.studentorg.berkeley.edu
 
 # added 2020-04-19 jaw rt#8997 rt#9027
 bamlab bamlab.berkeley.edu
+bamlab bamlab.studentorg.berkeley.edu
 
 # added 2020-03-14 jaw rt#8927 pending name change
 # update 2020-0324 minos - still pending name change
 # update 2020-04-17 jaw confirmed
 shack shac.berkeley.edu
+shack shac.studentorg.berkeley.edu
 
 # added 2020-04-16 jaw rt#9006
 spaceenterprise seb.berkeley.edu
+spaceenterprise seb.studentorg.berkeley.edu
 
 # added 2020-04-13 jaw rt#9000
 blueprint blueprint.berkeley.edu
+blueprint blueprint.studentorg.berkeley.edu
 
 # added 2020-04-12 jaw rt#9001
 ansberkeley ans.berkeley.edu
+ansberkeley ans.studentorg.berkeley.edu
 
 # added 2020-04-10 jaw rt#8998
 swe swe.berkeley.edu
+swe swe.studentorg.berkeley.edu
 
 # added 2020-04-07 jaw rt#8992
 psr psr.berkeley.edu
+psr psr.studentorg.berkeley.edu
 
 # added 2020-04-06 kmo rt#8990
 calsmv smv.berkeley.edu
+calsmv smv.studentorg.berkeley.edu
 
 # added 2020-03-04 vio in-person
 tassellink tassellink.berkeley.edu
+tassellink tassellink.studentorg.berkeley.edu
 
 # addded 2020-03-01 minos in-person
 auvs urobotics.berkeley.edu
+auvs urobotics.studentorg.berkeley.edu
 
 # addded 2020-02-26 jaw rt#8857
 skynx skynx.berkeley.edu
+skynx skynx.studentorg.berkeley.edu
 
 # added 2020-02-26 jaw rt#8874
 hyperloop ev.berkeley.edu
+hyperloop ev.studentorg.berkeley.edu
 
 # added 2020-02-24 snarain in-person
 plextech plextech.berkeley.edu
+plextech plextech.studentorg.berkeley.edu
 
 # added 2020-02-22 jaw rt#8856
 accelerateher accelerateher.berkeley.edu
+accelerateher accelerateher.studentorg.berkeley.edu
 
 # added 2020-02-20 jaw rt#8850
 pcs pcs.berkeley.edu
+pcs pcs.studentorg.berkeley.edu
 
 # added 2020-02-20 fydai in-persion
 businessreview businessreview.berkeley.edu
+businessreview businessreview.studentorg.berkeley.edu
 
 # added 2020-02-16 cooperc rt#8584
 brasa brasa.berkeley.edu
+brasa brasa.studentorg.berkeley.edu
 
 # added 2020-02-07 jaw rt#8808
 techsocialimpact tsihacks.berkeley.edu
+techsocialimpact tsihacks.studentorg.berkeley.edu
 
 # added 2020-02-07 cooperc in-person
 # updated 2020-02-16 cooperc rt#8807
 alzheimers alzassociation.berkeley.edu
+alzheimers alzassociation.studentorg.berkeley.edu
 
 # added 2020-02-06 jaw in-person
 btnberkeley btn.berkeley.edu
+btnberkeley btn.studentorg.berkeley.edu
 
 # added 2020-01-31 cooperc in-person
 pts pts.berkeley.edu
+pts pts.studentorg.berkeley.edu
 
 #added 2020-01-30 fydai rt#8681
 # fixed cooperc 2020-02-11
 rrrc raices.berkeley.edu
+rrrc raices.studentorg.berkeley.edu
 
 #added 2020-01-28 jaw rt#8785
 bbi bbi.berkeley.edu
+bbi bbi.studentorg.berkeley.edu
 
 # added 2020-01-24 jaw rt#8767
 vcb vc.berkeley.edu
+vcb vc.studentorg.berkeley.edu
 
 # added 2020-01-19 jaw rt#8749
 bridges bridges.berkeley.edu
+bridges bridges.studentorg.berkeley.edu
 
 # added 2020-01-18 jaw rt#8745
 # update 2020-01-22 cooperc rt#8760
 movefellowship movefellowship.berkeley.edu
+movefellowship movefellowship.studentorg.berkeley.edu
 
 # added 2019-12-05 abizer rt#8699
 aua aua.berkeley.edu
+aua aua.studentorg.berkeley.edu
 
 # added 2019-11-26 dkessler rt#8623
 bearconnections bearconnections.berkeley.edu
+bearconnections bearconnections.studentorg.berkeley.edu
 
 # added 2019-11-03 tonylian in-person
 bcssa bcssa.berkeley.edu
+bcssa bcssa.studentorg.berkeley.edu
 
 # added 2019-10-21 cooperc in-person
 sro sro.berkeley.edu
+sro sro.studentorg.berkeley.edu
 
 # added 2019-10-15 fydai rt#8538
 boaa boaa.berkeley.edu
+boaa boaa.studentorg.berkeley.edu
 
 # added 2019-10-14 cooperc in-person
 nscb nscb.berkeley.edu
+nscb nscb.studentorg.berkeley.edu
 
 # added 2019-09-23 abizer rt#8523
 barestge barestage.berkeley.edu
+barestge barestage.studentorg.berkeley.edu
 
 # added 2019-09-23 minos in-person
 uav uavs.berkeley.edu
+uav uavs.studentorg.berkeley.edu
 
 # added 2019-09-09 minos in-person
 uav aerobear.berkeley.edu
+uav aerobear.studentorg.berkeley.edu
 
 # added 2019-09-05 abizer rt#8441
 vrab xr.berkeley.edu
+vrab xr.studentorg.berkeley.edu
 
 # added 2019-08-29 adityasri rt#8454
 bicycal bicycal.berkeley.edu
+bicycal bicycal.studentorg.berkeley.edu
 
 # added 2019-08-28 abizer rt#8446
 bipla privlab.berkeley.edu
+bipla privlab.studentorg.berkeley.edu
 
 # added 2019-08-16 abizer rt#8415
 appnet appnet.berkeley.edu
+appnet appnet.studentorg.berkeley.edu
 
 # added 2019-08-06 adityasri rt#8394
 hurling hurling.berkeley.edu
+hurling hurling.studentorg.berkeley.edu
 
 # added 2019-05-20 seanvernon in-person
 ucbmun bearmun.berkeley.edu
+ucbmun bearmun.studentorg.berkeley.edu
 
 # added 2019-05-14 dkessler rt#8277
 dancethebay dancethebay.berkeley.edu
+dancethebay dancethebay.studentorg.berkeley.edu
 
 # added 2019-04-16 abizer rt#8199
 bridgeyear bridgeyear.berkeley.edu
+bridgeyear bridgeyear.studentorg.berkeley.edu
 
 # added 2019-04-13 minos in-person
 uav autocal.berkeley.edu
+uav autocal.studentorg.berkeley.edu
 
 # added 2019-04-11 cooperc rt#8185
 hcg hcg.berkeley.edu
+hcg hcg.studentorg.berkeley.edu
 
 # added 2019-04-01 dkessler rt#8152
 lasr lasr.berkeley.edu
+lasr lasr.studentorg.berkeley.edu
 
 # added 2019-03-21 dkessler in-person
 mlo mlo.berkeley.edu
+mlo mlo.studentorg.berkeley.edu
 
 #added 2019-03-18 abizer in-person
 aurum aurum.berkeley.edu
+aurum aurum.studentorg.berkeley.edu
 
 # added 2019-03-13 abizer in-person
 toppa toppa.berkeley.edu
+toppa toppa.studentorg.berkeley.edu
 
 # added 2019-02-28 keur in person
 invent inventabroad.berkeley.edu
+invent inventabroad.studentorg.berkeley.edu
 
 # added 2019-02-26 abizer rt#8055
 hyperloop hyperloop.berkeley.edu
+hyperloop hyperloop.studentorg.berkeley.edu
 
 # added 2019-02
 mri mri.berkeley.edu
+mri mri.studentorg.berkeley.edu
 
 # added 2019-02-09 dkessler rt#7997
 tbp tbp.berkeley.edu
+tbp tbp.studentorg.berkeley.edu
 
 # added 2019-02-05 dkessler rt#7996
 giant giantfilmmakers.berkeley.edu
+giant giantfilmmakers.studentorg.berkeley.edu
 
 # added 2019-02-05 abizer rt#7999
 seedofhealth bmri.berkeley.edu
+seedofhealth bmri.studentorg.berkeley.edu
 
 # added 2019-02-01 cooperc in-person
 history phat.berkeley.edu
+history phat.studentorg.berkeley.edu
 
 # added 2019-01-27 dkessler rt#7970
 laya laya.berkeley.edu
+laya laya.studentorg.berkeley.edu
 
 # added 2019-01-18 seanvernon in-person
 ucbmun mun.berkeley.edu
+ucbmun mun.studentorg.berkeley.edu
 # added 2019-04-18 cooperc in-person
 # non berkeley.edu approved by cooperc
 ucbmun ucbmun.org
 
 # added 2019-01-16 abizer rt#7932
 pasae pasae.berkeley.edu
+pasae pasae.studentorg.berkeley.edu
 
 # added 2019-01-13 abizer rt#7923
 ownit ownit.berkeley.edu
+ownit ownit.studentorg.berkeley.edu
 
 # added 2018-11-24 dkessler rt#7828
 databears db.berkeley.edu
+databears db.studentorg.berkeley.edu
 
 # added 2018-11-07 keur in-person
 epsilonpi epsilonpi.berkeley.edu
+epsilonpi epsilonpi.studentorg.berkeley.edu
 
 # added 2018-11-07 keur in-person
 ses ses.berkeley.edu
+ses ses.studentorg.berkeley.edu
 
 # added 2018-11-07 keur in-person
 bearwolf bgb.berkeley.edu
+bearwolf bgb.studentorg.berkeley.edu
 
 # added 2018-10-29 dkessler rt#7717
 breathe breathe.berkeley.edu
+breathe breathe.studentorg.berkeley.edu
 
 # added 2018-10-18 dkessler rt#7716
 rohp rohp.berkeley.edu
+rohp rohp.studentorg.berkeley.edu
 
 # added 2018-10-26 dkessler rt#7708
 beyond beyondacademia.berkeley.edu
+beyond beyondacademia.studentorg.berkeley.edu
 
 # added 2018-10-22 abizer rt#7694
 krober kas.berkeley.edu
+krober kas.studentorg.berkeley.edu
 
 # added 2018-10-18 mdcha in-person
 brb bail.berkeley.edu
+brb bail.studentorg.berkeley.edu
 
 # added 2018-10-15 dkessler rt#7676
 circlek cki.berkeley.edu
+circlek cki.studentorg.berkeley.edu
 
 # added 2018-10-13 abizer rt#7644
 bapscampus bcf.berkeley.edu
+bapscampus bcf.studentorg.berkeley.edu
 
 # added 2018-9-29 bchieng (in person)
 qtsab qtsab.berkeley.edu
+qtsab qtsab.studentorg.berkeley.edu
 
 # added 2018-09-29 abizer rt#7624
 reach reach.berkeley.edu
+reach reach.studentorg.berkeley.edu
 
 # added 2018-09-25 seanvernon rt#7616
 urec urec.berkeley.edu
+urec urec.studentorg.berkeley.edu
 
 # added 2018-09-12 mdcha (staff hours)
 neurotech neurotech.berkeley.edu
+neurotech neurotech.studentorg.berkeley.edu
 
 # added 2018-09-20 dkessler (staff hours)
 epoch epoch.berkeley.edu
+epoch epoch.studentorg.berkeley.edu
 # changed 2019-10-13 php (in person)
 epoch pdab.berkeley.edu
+epoch pdab.studentorg.berkeley.edu
 
 # added 2018-09-12 mdcha (staff hours)
 mmhi mmhi.berkeley.edu
+mmhi mmhi.studentorg.berkeley.edu
 
 # added 2018-09-11 dkessler rt#7568
 sasc sasc.berkeley.edu
+sasc sasc.studentorg.berkeley.edu
 
 # added 2018-09-04 keur rt#7325
 hackthebay calhacks.io
 
 # added 2018-08-30 dkessler rt#7536
 mtab mtab.berkeley.edu
+mtab mtab.studentorg.berkeley.edu
 
 # added 2018-08-28 mdcha (in person)
 calop fiatlux.berkeley.edu
+calop fiatlux.studentorg.berkeley.edu
 
 # added 2018-08-28 abizer rt#7514
 engle e98.berkeley.edu
+engle e98.studentorg.berkeley.edu
 
 # added 2018-08-22 abizer rt#7500
 dabestlab edens.berkeley.edu
+dabestlab edens.studentorg.berkeley.edu
 
 # added 2018-08-17 abizer rt#7477
 itsdecal introtosurgery.berkeley.edu
+itsdecal introtosurgery.studentorg.berkeley.edu
 
 # added 2018-07-31 abizer rt#7457
 ctennis bta.berkeley.edu
+ctennis bta.studentorg.berkeley.edu
 
 # added 2018-07-10 keur #rt7406
 idegroup ide.berkeley.edu
+idegroup ide.studentorg.berkeley.edu
 
 # added 2018-06-19 rt#7395
 pass pass.berkeley.edu
+pass pass.studentorg.berkeley.edu
 
 # added 2018-06-01 wporr
 # changed rt#9489
 gamecraft gamedev.berkeley.edu
+gamecraft gamedev.studentorg.berkeley.edu
 
 # added 2018-05-20 abizer
 vss venture.berkeley.edu
+vss venture.studentorg.berkeley.edu
 
 # 2018-05-18 rt#7342 wporr
 ewb ewb.berkeley.edu
+ewb ewb.studentorg.berkeley.edu
 
 # 2018-05-04 rt#7314 jvperrin
 isa isa.berkeley.edu
+isa isa.studentorg.berkeley.edu
 
 # 2018-05-01 rt#7295 bzh
 construction constructionteam.berkeley.edu
+construction constructionteam.studentorg.berkeley.edu
 
 # 2018-03-26 rt#7216 dkessler
 utk utk.berkeley.edu
+utk utk.studentorg.berkeley.edu
 
 # 2018-03-23 (staff hours) keur
 ahub ahlulbaytsociety.berkeley.edu
+ahub ahlulbaytsociety.studentorg.berkeley.edu
 
 # 2018-03-12 rt#7185 bzh
 eatb entrepreneurs.berkeley.edu
+eatb entrepreneurs.studentorg.berkeley.edu
 
 # 2018-03-03 rt#7165
 chec chec.berkeley.edu
+chec chec.studentorg.berkeley.edu
 
 # 2018-03-08 rt#7172 keur
 nicugroup nicu.berkeley.edu
+nicugroup nicu.studentorg.berkeley.edu
 
 # 2018-02-22 rt#7121 abizer
 bpreview bpr.berkeley.edu
+bpreview bpr.studentorg.berkeley.edu
 
 # 2018-02-07 (in person) jvperrin
 neri neurolab.berkeley.edu
+neri neurolab.studentorg.berkeley.edu
 
 # 2018-02-06 rt#7059 abizer
 qcb qcb.berkeley.edu
+qcb qcb.studentorg.berkeley.edu
 
 # 2018-01-26 rt#7015 keur
 dsi dsi.berkeley.edu
+dsi dsi.studentorg.berkeley.edu
 
 # 2018-01-23 rt#6996 abizer
 beacn beacn.berkeley.edu
+beacn beacn.studentorg.berkeley.edu
 
 # 2018-01-16 rt#6952 abizer
 berkeleet berke1337.berkeley.edu
+berkeleet berke1337.studentorg.berkeley.edu
 
 # 2018-01-16 rt#6951 abizer
 caltv caltv.berkeley.edu
+caltv caltv.studentorg.berkeley.edu
 
 # 2018-01-16 rt#6949 abizer
 mccb mccb.berkeley.edu
+mccb mccb.studentorg.berkeley.edu
 
 # 2018-01-15 rt#6907 abizer
 bioprinting bioprinting.berkeley.edu
+bioprinting bioprinting.studentorg.berkeley.edu
 
 # 2018-01-05 rt#6929 abizer
 calite ite.berkeley.edu
+calite ite.studentorg.berkeley.edu
 
 # 2017-12-25 rt#6919 keur
 bppj bppj.berkeley.edu
+bppj bppj.studentorg.berkeley.edu
 
 # 2017-11-30 rt#6867 abizer
 lipb ulhs.berkeley.edu
+lipb ulhs.studentorg.berkeley.edu
 
 # 2017-11-29 rt#6863 chuang
 moveme moveme.berkeley.edu
+moveme moveme.studentorg.berkeley.edu
 
 # 2017-11-29 rt#6860 keur
 bhi bhi.berkeley.edu
+bhi bhi.studentorg.berkeley.edu
 
 # 2017-11-21 rt#6841 keur
 ace ace.berkeley.edu
+ace ace.studentorg.berkeley.edu
 
 # 2017-11-06 rt#6780 keur
 geostudents geostudents.berkeley.edu
+geostudents geostudents.studentorg.berkeley.edu
 
 # 2017-11-01 rt#6767 abizer
 sheleads sheleads.berkeley.edu
+sheleads sheleads.studentorg.berkeley.edu
 
 # 207-10-30 rt#6736 abizer
 sciencepolicy sciencepolicy.berkeley.edu
+sciencepolicy sciencepolicy.studentorg.berkeley.edu
 
 # 2017-10-27 rt#6727 ckuehl
 sinmaysa ssa.berkeley.edu
+sinmaysa ssa.studentorg.berkeley.edu
 
 # 2017-10-20 rt#6691 abizer
 efork e4k.berkeley.edu
+efork e4k.studentorg.berkeley.edu
 
 # 2017-10-19 rt#6675 abizer
 terraetc terra.berkeley.edu
+terraetc terra.studentorg.berkeley.edu
 
 # 2017-10-19 rt#6682 abizer
 gdso gdso.berkeley.edu
+gdso gdso.studentorg.berkeley.edu
 
 # 2017-10-05 rt#6647 kpengboy
 helios helios.berkeley.edu
+helios helios.studentorg.berkeley.edu
 
 # 2017-09-25 rt#6622 abizer
 pha pha.berkeley.edu
+pha pha.studentorg.berkeley.edu
 
 # 2017-09-24 rt#6616 abizer
 dssb dss.berkeley.edu
+dssb dss.studentorg.berkeley.edu
 
 # 2017-09-09 rt#6531 abizer
 icb icb.berkeley.edu
+icb icb.studentorg.berkeley.edu
 
 # 2017-08-25 rt#6454 ckuehl
 # changed rt#9252
 ssscr tmsca.berkeley.edu
+ssscr tmsca.studentorg.berkeley.edu
 
 # 2017-08-25 rt#6449 abizer
 ushp ushp.berkeley.edu
+ushp ushp.studentorg.berkeley.edu
 
 # 2017-08-21 rt#6418 abizer
 ssc ssc.berkeley.edu
+ssc ssc.studentorg.berkeley.edu
 
 # 2017-08-14 rt#6417 abizer
 # 2018-08-28 rt#8444 abizer susa renamed to saas
 # jaw: removed old susa domain
 ugradsa saas.berkeley.edu
+ugradsa saas.studentorg.berkeley.edu
 
 # 2017-08-11 (self) abizer
 decal decal.ocf.berkeley.edu
 
 # 2017-07-20 rt#6377 abizer
 debsoc debate.berkeley.edu
+debsoc debate.studentorg.berkeley.edu
 
 # 2017-07-12 rt#6327 abizer
 calsteel steelbridge.berkeley.edu
+calsteel steelbridge.studentorg.berkeley.edu
 
 aacf aacf.berkeley.edu
+aacf aacf.studentorg.berkeley.edu
 aez aez.berkeley.edu
+aez aez.studentorg.berkeley.edu
 aiaa aiaa.berkeley.edu
+aiaa aiaa.studentorg.berkeley.edu
 alumni casa.berkeley.edu
+alumni casa.studentorg.berkeley.edu
 analytic aoc.berkeley.edu
+analytic aoc.studentorg.berkeley.edu
 archery archery.berkeley.edu
+archery archery.studentorg.berkeley.edu
 asme asme.berkeley.edu
+asme asme.studentorg.berkeley.edu
 backgammon blb.berkeley.edu
+backgammon blb.studentorg.berkeley.edu
 badmintn badminton.berkeley.edu
+badmintn badminton.studentorg.berkeley.edu
 bcab bcab.berkeley.edu
+bcab bcab.studentorg.berkeley.edu
 bconsult bc.berkeley.edu
+bconsult bc.studentorg.berkeley.edu
 bforum forum.berkeley.edu
+bforum forum.studentorg.berkeley.edu
 bforum forum.berkeley.edu
+bforum forum.studentorg.berkeley.edu
 bioehs bioehs.berkeley.edu
+bioehs bioehs.studentorg.berkeley.edu
 bitcoin bitcoin.berkeley.edu
+bitcoin bitcoin.studentorg.berkeley.edu
 bitcoin blockchain.berkeley.edu
+bitcoin blockchain.studentorg.berkeley.edu
 bluegold yearbook.berkeley.edu
+bluegold yearbook.studentorg.berkeley.edu
 bpg bpsychologygroup.berkeley.edu
+bpg bpsychologygroup.studentorg.berkeley.edu
 breadclub bread.berkeley.edu
+breadclub bread.studentorg.berkeley.edu
 calconst calconstruction.berkeley.edu
+calconst calconstruction.studentorg.berkeley.edu
 caleague actuary.berkeley.edu
+caleague actuary.studentorg.berkeley.edu
 cglc cglc.berkeley.edu
+cglc cglc.studentorg.berkeley.edu
 choral ucchoral.berkeley.edu
+choral ucchoral.studentorg.berkeley.edu
 choral ucchoral.berkeley.edu
+choral ucchoral.studentorg.berkeley.edu
 cia invest.berkeley.edu
+cia invest.studentorg.berkeley.edu
 codebase codebase.berkeley.edu
+codebase codebase.studentorg.berkeley.edu
 cssa cssa.berkeley.edu
+cssa cssa.studentorg.berkeley.edu
 cycling cycling.berkeley.edu
+cycling cycling.studentorg.berkeley.edu
 diabears d1abears.berkeley.edu
+diabears d1abears.studentorg.berkeley.edu
 dts drawntoscale.berkeley.edu
+dts drawntoscale.studentorg.berkeley.edu
 eau eau.berkeley.edu
+eau eau.studentorg.berkeley.edu
 eerlab eerlab.berkeley.edu
+eerlab eerlab.studentorg.berkeley.edu
 ejc esc.berkeley.edu
+ejc esc.studentorg.berkeley.edu
 eleven eleven.berkeley.edu
+eleven eleven.studentorg.berkeley.edu
 enablet enabletech.berkeley.edu
+enablet enabletech.studentorg.berkeley.edu
 enactus enactus.berkeley.edu
+enactus enactus.studentorg.berkeley.edu
 eswb esw.berkeley.edu
+eswb esw.studentorg.berkeley.edu
 ethical ethicalapparel.org
 ewb ewb.berkeley.edu
+ewb ewb.studentorg.berkeley.edu
 feed feed.berkeley.edu
+feed feed.studentorg.berkeley.edu
 foodinno foodinno.berkeley.edu
+foodinno foodinno.studentorg.berkeley.edu
 foodsci fst.berkeley.edu
+foodsci fst.studentorg.berkeley.edu
 hmap hmap.berkeley.edu
+hmap hmap.studentorg.berkeley.edu
 hsab hsab.berkeley.edu
+hsab hsab.studentorg.berkeley.edu
 igs igenspectrum.berkeley.edu
+igs igenspectrum.studentorg.berkeley.edu
 isab isab.berkeley.edu
+isab isab.studentorg.berkeley.edu
 isac isac.berkeley.edu
+isac isac.studentorg.berkeley.edu
 ixic ixic.berkeley.edu
+ixic ixic.studentorg.berkeley.edu
 karate karate.berkeley.edu
+karate karate.studentorg.berkeley.edu
 knowyouruni knowyouruniversity.berkeley.edu
+knowyouruni knowyouruniversity.studentorg.berkeley.edu
 mlab ml.berkeley.edu
+mlab ml.studentorg.berkeley.edu
 morningsignout morningsignout.berkeley.edu
+morningsignout morningsignout.studentorg.berkeley.edu
 msa msa.berkeley.edu
+msa msa.studentorg.berkeley.edu
 msea msea.berkeley.edu
+msea msea.studentorg.berkeley.edu
 mto sufiassociation.berkeley.edu
+mto sufiassociation.studentorg.berkeley.edu
 nib nib.berkeley.edu
+nib nib.studentorg.berkeley.edu
 nsls nsls.berkeley.edu
+nsls nsls.studentorg.berkeley.edu
 nsu nsu.berkeley.edu
+nsu nsu.studentorg.berkeley.edu
 nutmeg nutmeg.berkeley.edu
+nutmeg nutmeg.studentorg.berkeley.edu
 oai oa.berkeley.edu
+oai oa.studentorg.berkeley.edu
 onehundredstrong onehundredstrong.berkeley.edu
+onehundredstrong onehundredstrong.studentorg.berkeley.edu
 pcg phoenix.berkeley.edu
+pcg phoenix.studentorg.berkeley.edu
 perspect perspective.berkeley.edu
+perspect perspective.studentorg.berkeley.edu
 pmhs pmhs.berkeley.edu
+pmhs pmhs.studentorg.berkeley.edu
 pokemon pkmn.berkeley.edu
+pokemon pkmn.studentorg.berkeley.edu
 polish polishclub.berkeley.edu
+polish polishclub.studentorg.berkeley.edu
 ppgs fly.berkeley.edu
+ppgs fly.studentorg.berkeley.edu
 projectscifi projectscifi.org
 ptps ptps.berkeley.edu
+ptps ptps.studentorg.berkeley.edu
 quiparle quiparle.berkeley.edu
+quiparle quiparle.studentorg.berkeley.edu
 recycle recycle.berkeley.edu
+recycle recycle.studentorg.berkeley.edu
 reuse reuse.berkeley.edu
+reuse reuse.studentorg.berkeley.edu
 robobears robobears.berkeley.edu
+robobears robobears.studentorg.berkeley.edu
 robotics rab.berkeley.edu
+robotics rab.studentorg.berkeley.edu
 
 #CNAME only, plus changing to raices.be
 #see rt#8681 -cooperc
 #rrrc raza.berkeley.edu
 
 rtsa rtsa.berkeley.edu
+rtsa rtsa.studentorg.berkeley.edu
 sailing sailing.berkeley.edu
+sailing sailing.studentorg.berkeley.edu
 sca sca.berkeley.edu
+sca sca.studentorg.berkeley.edu
 scc seniorclasscouncil.berkeley.edu
+scc seniorclasscouncil.studentorg.berkeley.edu
 sesb sesb.berkeley.edu
+sesb sesb.studentorg.berkeley.edu
 see see.berkeley.edu
+see see.studentorg.berkeley.edu
 sigma axs.berkeley.edu
+sigma axs.studentorg.berkeley.edu
 skiteam skiteam.berkeley.edu
+skiteam skiteam.studentorg.berkeley.edu
 songwriting songwriting.berkeley.edu
+songwriting songwriting.studentorg.berkeley.edu
 speech speech.berkeley.edu
+speech speech.studentorg.berkeley.edu
 spie photobears.berkeley.edu
+spie photobears.studentorg.berkeley.edu
 squelch squelched.com
 stac stac.berkeley.edu
+stac stac.studentorg.berkeley.edu
 startup startup.berkeley.edu
+startup startup.studentorg.berkeley.edu
 uaem uaem.berkeley.edu
+uaem uaem.studentorg.berkeley.edu
 uav uav.berkeley.edu
+uav uav.studentorg.berkeley.edu
 uea econreview.berkeley.edu
+uea econreview.studentorg.berkeley.edu
 ulab ulab.berkeley.edu
+ulab ulab.studentorg.berkeley.edu
 unab unab.berkeley.edu
+unab unab.studentorg.berkeley.edu
 unicef unicef.berkeley.edu
+unicef unicef.studentorg.berkeley.edu
 unrac unrac.berkeley.edu
+unrac unrac.studentorg.berkeley.edu
 upe upe.berkeley.edu
 upe upe.cs.berkeley.edu
 vcb vcb.berkeley.edu
+vcb vcb.studentorg.berkeley.edu
 vcg vcg.berkeley.edu
+vcg vcg.studentorg.berkeley.edu
 vhio vhio.berkeley.edu
+vhio vhio.studentorg.berkeley.edu
 vmo vmo.berkeley.edu
+vmo vmo.studentorg.berkeley.edu
 vrab vr.berkeley.edu
+vrab vr.studentorg.berkeley.edu
 wsladmin wordsoundlife.berkeley.edu
+wsladmin wordsoundlife.studentorg.berkeley.edu


### PR DESCRIPTION
- add .studentorg.berkeley.edu mail hosts
- remove old non-studentorg mail vhosts
