### PR TITLE
Nanotech cname remove studentorg

### DIFF
--- a/configs/vhost-app.conf
+++ b/configs/vhost-app.conf
@@ -37,7 +37,7 @@ lead app-lead.berkeley.edu - -
 eecsdiscord bot-eecsdiscord.studentorg.berkeley.edu - bot-eecsdiscord.berkeley.edu
 
 # ronitnath
-nanotech nanotech.studentorg.berkeley.edu - nanotech.berkeley.edu
+nanotech nanotech.berkeley.edu - nanotech.berkeley.edu
 
 # ronitnath
 spaceenterprise seb.studentorg.berkeley.edu - seb.berkeley.edu


### PR DESCRIPTION
Nanotech is a research lab, and should not be under the studentorg subdomain