### PR TITLE
added vhost for lmcevoy

### DIFF
--- a/configs/vhost.conf
+++ b/configs/vhost.conf
@@ -16,6 +16,9 @@
 #             This field can be ommitted entirely (no dash needed).
 #
 # (use dashes to omit a field)
+# rt#14572 by storce
+lmcevoy handprint.anthro.berkeley.edu - -
+
 # staff-hour by storce
 hiftu hiftu.studentorg.berkeley.edu - -
 


### PR DESCRIPTION
dns record for handprint.antro.berkeley.edu already approved. See rt#14572 for more detail.